### PR TITLE
fix: restore pending input changeset

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -14,7 +14,6 @@
 		"orange-otters-jump",
 		"polite-hotels-knock",
 		"six-pens-think",
-		"solid-input-basics",
 		"smooth-seals-drive",
 		"stale-pets-cheer",
 		"tidy-planes-repair"


### PR DESCRIPTION
## Summary
- remove `solid-input-basics` from `.changeset/pre.json`
- restore the Input changeset as pending in prerelease mode
- allow Changesets to open the next release PR for `1.0.0-alpha.8`

## Validation
- bunx prettier --check .changeset/pre.json
- bunx changeset status