### PR TITLE
feat: migrate ComboBox.Input to use shared Input primitive while maintaining accessibility

### DIFF
--- a/.agents/skills/svelte5-best-practices/references/migration.md
+++ b/.agents/skills/svelte5-best-practices/references/migration.md
@@ -39,14 +39,15 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-  let items = [];
-  let filter = 'all';
+	let items = [];
+	let filter = 'all';
+	let filteredItems = [];
 
-  $: filteredItems = {
-    if (filter === 'all') return items;
-    if (filter === 'active') return items.filter(i => !i.done);
-    return items.filter(i => i.done);
-  };
+	$: {
+		if (filter === 'all') filteredItems = items;
+		else if (filter === 'active') filteredItems = items.filter((i) => !i.done);
+		else filteredItems = items.filter((i) => i.done);
+	}
 </script>
 ```
 

--- a/.agents/skills/svelte5-best-practices/references/migration.md
+++ b/.agents/skills/svelte5-best-practices/references/migration.md
@@ -17,9 +17,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let count = 0;
- $: doubled = count * 2;
- $: quadrupled = doubled * 2;
+	let count = 0;
+	$: doubled = count * 2;
+	$: quadrupled = doubled * 2;
 </script>
 ```
 
@@ -27,9 +27,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let count = $state(0);
- let doubled = $derived(count * 2);
- let quadrupled = $derived(doubled * 2);
+	let count = $state(0);
+	let doubled = $derived(count * 2);
+	let quadrupled = $derived(doubled * 2);
 </script>
 ```
 
@@ -39,15 +39,15 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let items = [];
- let filter = 'all';
- let filteredItems = [];
+	let items = [];
+	let filter = 'all';
+	let filteredItems = [];
 
- $: {
-  if (filter === 'all') filteredItems = items;
-  else if (filter === 'active') filteredItems = items.filter((i) => !i.done);
-  else filteredItems = items.filter((i) => i.done);
- }
+	$: {
+		if (filter === 'all') filteredItems = items;
+		else if (filter === 'active') filteredItems = items.filter((i) => !i.done);
+		else filteredItems = items.filter((i) => i.done);
+	}
 </script>
 ```
 
@@ -55,14 +55,14 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let items = $state([]);
- let filter = $state('all');
+	let items = $state([]);
+	let filter = $state('all');
 
- let filteredItems = $derived.by(() => {
-  if (filter === 'all') return items;
-  if (filter === 'active') return items.filter((i) => !i.done);
-  return items.filter((i) => i.done);
- });
+	let filteredItems = $derived.by(() => {
+		if (filter === 'all') return items;
+		if (filter === 'active') return items.filter((i) => !i.done);
+		return items.filter((i) => i.done);
+	});
 </script>
 ```
 
@@ -72,9 +72,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let count = 0;
- $: console.log('Count changed:', count);
- $: document.title = `Count: ${count}`;
+	let count = 0;
+	$: console.log('Count changed:', count);
+	$: document.title = `Count: ${count}`;
 </script>
 ```
 
@@ -82,14 +82,14 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let count = $state(0);
+	let count = $state(0);
 
- $effect(() => {
-  console.log('Count changed:', count);
- });
- $effect(() => {
-  document.title = `Count: ${count}`;
- });
+	$effect(() => {
+		console.log('Count changed:', count);
+	});
+	$effect(() => {
+		document.title = `Count: ${count}`;
+	});
 </script>
 ```
 
@@ -99,10 +99,10 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let value;
- $: if (value > 100) {
-  alert('Value too high!');
- }
+	let value;
+	$: if (value > 100) {
+		alert('Value too high!');
+	}
 </script>
 ```
 
@@ -110,13 +110,13 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let value = $state(0);
+	let value = $state(0);
 
- $effect(() => {
-  if (value > 100) {
-   alert('Value too high!');
-  }
- });
+	$effect(() => {
+		if (value > 100) {
+			alert('Value too high!');
+		}
+	});
 </script>
 ```
 
@@ -126,9 +126,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- export let name;
- export let count = 0;
- $: greeting = `Hello, ${name}!`;
+	export let name;
+	export let count = 0;
+	$: greeting = `Hello, ${name}!`;
 </script>
 ```
 
@@ -136,8 +136,8 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let { name, count = 0 } = $props();
- let greeting = $derived(`Hello, ${name}!`);
+	let { name, count = 0 } = $props();
+	let greeting = $derived(`Hello, ${name}!`);
 </script>
 ```
 
@@ -147,17 +147,17 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- import { onDestroy } from 'svelte';
+	import { onDestroy } from 'svelte';
 
- let count = 0;
- let interval;
+	let count = 0;
+	let interval;
 
- $: {
-  clearInterval(interval);
-  interval = setInterval(() => console.log(count), 1000);
- }
+	$: {
+		clearInterval(interval);
+		interval = setInterval(() => console.log(count), 1000);
+	}
 
- onDestroy(() => clearInterval(interval));
+	onDestroy(() => clearInterval(interval));
 </script>
 ```
 
@@ -165,12 +165,12 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
- let count = $state(0);
+	let count = $state(0);
 
- $effect(() => {
-  const interval = setInterval(() => console.log(count), 1000);
-  return () => clearInterval(interval); // Cleanup built-in
- });
+	$effect(() => {
+		const interval = setInterval(() => console.log(count), 1000);
+		return () => clearInterval(interval); // Cleanup built-in
+	});
 </script>
 ```
 
@@ -204,12 +204,12 @@ Svelte 5 runes can replace most store use cases with simpler, more direct reacti
 
 ```svelte
 <script>
- import { writable } from 'svelte/store';
+	import { writable } from 'svelte/store';
 
- const count = writable(0);
- function increment() {
-  count.update((n) => n + 1);
- }
+	const count = writable(0);
+	function increment() {
+		count.update((n) => n + 1);
+	}
 </script>
 
 <button on:click={increment}>Count: {$count}</button>
@@ -219,10 +219,10 @@ Svelte 5 runes can replace most store use cases with simpler, more direct reacti
 
 ```svelte
 <script>
- let count = $state(0);
- function increment() {
-  count++;
- }
+	let count = $state(0);
+	function increment() {
+		count++;
+	}
 </script>
 
 <button onclick={increment}>Count: {count}</button>
@@ -245,13 +245,13 @@ export const user = $state<User | null>(null);
 export const theme = $state({ current: 'light' as 'light' | 'dark' });
 
 export function setTheme(newTheme: 'light' | 'dark') {
- theme.current = newTheme;
+	theme.current = newTheme;
 }
 ```
 
 ```svelte
 <script>
- import { theme, setTheme } from './state.svelte';
+	import { theme, setTheme } from './state.svelte';
 </script>
 
 <p>Theme: {theme.current}</p>
@@ -275,14 +275,14 @@ export const completedCount = derived(items, ($items) => $items.filter((i) => i.
 export const items = $state<Item[]>([]);
 
 export function getCompletedCount() {
- return items.filter((i) => i.done).length;
+	return items.filter((i) => i.done).length;
 }
 ```
 
 ```svelte
 <script>
- import { items } from './state.svelte';
- let completedCount = $derived(items.filter((i) => i.done).length);
+	import { items } from './state.svelte';
+	let completedCount = $derived(items.filter((i) => i.done).length);
 </script>
 ```
 
@@ -292,13 +292,13 @@ export function getCompletedCount() {
 
 ```ts
 function createCounter() {
- const { subscribe, set, update } = writable(0);
- return {
-  subscribe,
-  increment: () => update((n) => n + 1),
-  decrement: () => update((n) => n - 1),
-  reset: () => set(0)
- };
+	const { subscribe, set, update } = writable(0);
+	return {
+		subscribe,
+		increment: () => update((n) => n + 1),
+		decrement: () => update((n) => n - 1),
+		reset: () => set(0)
+	};
 }
 export const counter = createCounter();
 ```
@@ -308,16 +308,16 @@ export const counter = createCounter();
 ```ts
 // counter.svelte.ts
 class Counter {
- value = $state(0);
- increment() {
-  this.value++;
- }
- decrement() {
-  this.value--;
- }
- reset() {
-  this.value = 0;
- }
+	value = $state(0);
+	increment() {
+		this.value++;
+	}
+	decrement() {
+		this.value--;
+	}
+	reset() {
+		this.value = 0;
+	}
 }
 
 export const counter = new Counter();
@@ -325,7 +325,7 @@ export const counter = new Counter();
 
 ```svelte
 <script>
- import { counter } from './counter.svelte';
+	import { counter } from './counter.svelte';
 </script>
 
 <p>{counter.value}</p>
@@ -339,23 +339,23 @@ export const counter = new Counter();
 ```ts
 // api.svelte.ts
 export const state = $state({
- data: null as Data | null,
- loading: false,
- error: null as Error | null
+	data: null as Data | null,
+	loading: false,
+	error: null as Error | null
 });
 
 export async function fetchData() {
- state.loading = true;
- state.error = null;
+	state.loading = true;
+	state.error = null;
 
- try {
-  const res = await fetch('/api/data');
-  state.data = await res.json();
- } catch (e) {
-  state.error = e as Error;
- } finally {
-  state.loading = false;
- }
+	try {
+		const res = await fetch('/api/data');
+		state.data = await res.json();
+	} catch (e) {
+		state.error = e as Error;
+	} finally {
+		state.loading = false;
+	}
 }
 ```
 

--- a/.agents/skills/svelte5-best-practices/references/migration.md
+++ b/.agents/skills/svelte5-best-practices/references/migration.md
@@ -17,9 +17,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let count = 0;
-	$: doubled = count * 2;
-	$: quadrupled = doubled * 2;
+ let count = 0;
+ $: doubled = count * 2;
+ $: quadrupled = doubled * 2;
 </script>
 ```
 
@@ -27,9 +27,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let count = $state(0);
-	let doubled = $derived(count * 2);
-	let quadrupled = $derived(doubled * 2);
+ let count = $state(0);
+ let doubled = $derived(count * 2);
+ let quadrupled = $derived(doubled * 2);
 </script>
 ```
 
@@ -39,15 +39,15 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let items = [];
-	let filter = 'all';
-	let filteredItems = [];
+ let items = [];
+ let filter = 'all';
+ let filteredItems = [];
 
-	$: {
-		if (filter === 'all') filteredItems = items;
-		else if (filter === 'active') filteredItems = items.filter((i) => !i.done);
-		else filteredItems = items.filter((i) => i.done);
-	}
+ $: {
+  if (filter === 'all') filteredItems = items;
+  else if (filter === 'active') filteredItems = items.filter((i) => !i.done);
+  else filteredItems = items.filter((i) => i.done);
+ }
 </script>
 ```
 
@@ -55,14 +55,14 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let items = $state([]);
-	let filter = $state('all');
+ let items = $state([]);
+ let filter = $state('all');
 
-	let filteredItems = $derived.by(() => {
-		if (filter === 'all') return items;
-		if (filter === 'active') return items.filter((i) => !i.done);
-		return items.filter((i) => i.done);
-	});
+ let filteredItems = $derived.by(() => {
+  if (filter === 'all') return items;
+  if (filter === 'active') return items.filter((i) => !i.done);
+  return items.filter((i) => i.done);
+ });
 </script>
 ```
 
@@ -72,9 +72,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let count = 0;
-	$: console.log('Count changed:', count);
-	$: document.title = `Count: ${count}`;
+ let count = 0;
+ $: console.log('Count changed:', count);
+ $: document.title = `Count: ${count}`;
 </script>
 ```
 
@@ -82,14 +82,14 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let count = $state(0);
+ let count = $state(0);
 
-	$effect(() => {
-		console.log('Count changed:', count);
-	});
-	$effect(() => {
-		document.title = `Count: ${count}`;
-	});
+ $effect(() => {
+  console.log('Count changed:', count);
+ });
+ $effect(() => {
+  document.title = `Count: ${count}`;
+ });
 </script>
 ```
 
@@ -99,10 +99,10 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let value;
-	$: if (value > 100) {
-		alert('Value too high!');
-	}
+ let value;
+ $: if (value > 100) {
+  alert('Value too high!');
+ }
 </script>
 ```
 
@@ -110,13 +110,13 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let value = $state(0);
+ let value = $state(0);
 
-	$effect(() => {
-		if (value > 100) {
-			alert('Value too high!');
-		}
-	});
+ $effect(() => {
+  if (value > 100) {
+   alert('Value too high!');
+  }
+ });
 </script>
 ```
 
@@ -126,9 +126,9 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	export let name;
-	export let count = 0;
-	$: greeting = `Hello, ${name}!`;
+ export let name;
+ export let count = 0;
+ $: greeting = `Hello, ${name}!`;
 </script>
 ```
 
@@ -136,8 +136,8 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let { name, count = 0 } = $props();
-	let greeting = $derived(`Hello, ${name}!`);
+ let { name, count = 0 } = $props();
+ let greeting = $derived(`Hello, ${name}!`);
 </script>
 ```
 
@@ -147,17 +147,17 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	import { onDestroy } from 'svelte';
+ import { onDestroy } from 'svelte';
 
-	let count = 0;
-	let interval;
+ let count = 0;
+ let interval;
 
-	$: {
-		clearInterval(interval);
-		interval = setInterval(() => console.log(count), 1000);
-	}
+ $: {
+  clearInterval(interval);
+  interval = setInterval(() => console.log(count), 1000);
+ }
 
-	onDestroy(() => clearInterval(interval));
+ onDestroy(() => clearInterval(interval));
 </script>
 ```
 
@@ -165,12 +165,12 @@ Svelte 5 replaces `$:` with `$derived` (for values) and `$effect` (for side effe
 
 ```svelte
 <script>
-	let count = $state(0);
+ let count = $state(0);
 
-	$effect(() => {
-		const interval = setInterval(() => console.log(count), 1000);
-		return () => clearInterval(interval); // Cleanup built-in
-	});
+ $effect(() => {
+  const interval = setInterval(() => console.log(count), 1000);
+  return () => clearInterval(interval); // Cleanup built-in
+ });
 </script>
 ```
 
@@ -204,12 +204,12 @@ Svelte 5 runes can replace most store use cases with simpler, more direct reacti
 
 ```svelte
 <script>
-	import { writable } from 'svelte/store';
+ import { writable } from 'svelte/store';
 
-	const count = writable(0);
-	function increment() {
-		count.update((n) => n + 1);
-	}
+ const count = writable(0);
+ function increment() {
+  count.update((n) => n + 1);
+ }
 </script>
 
 <button on:click={increment}>Count: {$count}</button>
@@ -219,10 +219,10 @@ Svelte 5 runes can replace most store use cases with simpler, more direct reacti
 
 ```svelte
 <script>
-	let count = $state(0);
-	function increment() {
-		count++;
-	}
+ let count = $state(0);
+ function increment() {
+  count++;
+ }
 </script>
 
 <button onclick={increment}>Count: {count}</button>
@@ -245,13 +245,13 @@ export const user = $state<User | null>(null);
 export const theme = $state({ current: 'light' as 'light' | 'dark' });
 
 export function setTheme(newTheme: 'light' | 'dark') {
-	theme.current = newTheme;
+ theme.current = newTheme;
 }
 ```
 
 ```svelte
 <script>
-	import { theme, setTheme } from './state.svelte';
+ import { theme, setTheme } from './state.svelte';
 </script>
 
 <p>Theme: {theme.current}</p>
@@ -275,14 +275,14 @@ export const completedCount = derived(items, ($items) => $items.filter((i) => i.
 export const items = $state<Item[]>([]);
 
 export function getCompletedCount() {
-	return items.filter((i) => i.done).length;
+ return items.filter((i) => i.done).length;
 }
 ```
 
 ```svelte
 <script>
-	import { items } from './state.svelte';
-	let completedCount = $derived(items.filter((i) => i.done).length);
+ import { items } from './state.svelte';
+ let completedCount = $derived(items.filter((i) => i.done).length);
 </script>
 ```
 
@@ -292,13 +292,13 @@ export function getCompletedCount() {
 
 ```ts
 function createCounter() {
-	const { subscribe, set, update } = writable(0);
-	return {
-		subscribe,
-		increment: () => update((n) => n + 1),
-		decrement: () => update((n) => n - 1),
-		reset: () => set(0)
-	};
+ const { subscribe, set, update } = writable(0);
+ return {
+  subscribe,
+  increment: () => update((n) => n + 1),
+  decrement: () => update((n) => n - 1),
+  reset: () => set(0)
+ };
 }
 export const counter = createCounter();
 ```
@@ -308,16 +308,16 @@ export const counter = createCounter();
 ```ts
 // counter.svelte.ts
 class Counter {
-	value = $state(0);
-	increment() {
-		this.value++;
-	}
-	decrement() {
-		this.value--;
-	}
-	reset() {
-		this.value = 0;
-	}
+ value = $state(0);
+ increment() {
+  this.value++;
+ }
+ decrement() {
+  this.value--;
+ }
+ reset() {
+  this.value = 0;
+ }
 }
 
 export const counter = new Counter();
@@ -325,7 +325,7 @@ export const counter = new Counter();
 
 ```svelte
 <script>
-	import { counter } from './counter.svelte';
+ import { counter } from './counter.svelte';
 </script>
 
 <p>{counter.value}</p>
@@ -339,23 +339,23 @@ export const counter = new Counter();
 ```ts
 // api.svelte.ts
 export const state = $state({
-	data: null as Data | null,
-	loading: false,
-	error: null as Error | null
+ data: null as Data | null,
+ loading: false,
+ error: null as Error | null
 });
 
 export async function fetchData() {
-	state.loading = true;
-	state.error = null;
+ state.loading = true;
+ state.error = null;
 
-	try {
-		const res = await fetch('/api/data');
-		state.data = await res.json();
-	} catch (e) {
-		state.error = e as Error;
-	} finally {
-		state.loading = false;
-	}
+ try {
+  const res = await fetch('/api/data');
+  state.data = await res.json();
+ } catch (e) {
+  state.error = e as Error;
+ } finally {
+  state.loading = false;
+ }
 }
 ```
 

--- a/.changeset/strong-cars-smell.md
+++ b/.changeset/strong-cars-smell.md
@@ -1,0 +1,7 @@
+---
+'@human-kit/svelte-components': patch
+---
+
+# Summary
+
+Make `ComboBox.Input` render through the shared `Input` primitive while preserving existing combobox behavior and accessibility semantics.

--- a/packages/svelte/src/lib/combobox/input/combobox-input.svelte
+++ b/packages/svelte/src/lib/combobox/input/combobox-input.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import type { HTMLInputAttributes } from 'svelte/elements';
+	import { Input } from '../../input';
 	import { useComboBoxContext } from '../root/context';
 	import {
 		shouldShowFocusVisible,
@@ -17,11 +18,26 @@
 		class?: string;
 	};
 
+	function composeEventHandlers<TEvent extends Event>(
+		internalHandler: ((event: TEvent) => void) | undefined,
+		externalHandler: ((event: TEvent) => void) | undefined
+	): (event: TEvent) => void {
+		return (event: TEvent) => {
+			internalHandler?.(event);
+			externalHandler?.(event);
+		};
+	}
+
 	let {
 		'aria-label': ariaLabel,
 		'aria-labelledby': ariaLabelledby,
 		'aria-describedby': ariaDescribedby,
 		class: className,
+		oninput: onInputExternal,
+		onfocus: onFocusExternal,
+		onmousedown: onMouseDownExternal,
+		onblur: onBlurExternal,
+		onkeydown: onKeyDownExternal,
 		...restProps
 	}: ComboBoxInputProps = $props();
 
@@ -83,8 +99,8 @@
 	}
 </script>
 
-<input
-	bind:this={inputRef}
+<Input
+	bind:element={inputRef}
 	type="text"
 	role="combobox"
 	aria-autocomplete="list"
@@ -98,13 +114,13 @@
 	aria-labelledby={ariaLabelledby}
 	aria-describedby={ariaDescribedby}
 	value={ctx.displayValue}
-	disabled={ctx.isDisabled}
-	readonly={ctx.isReadOnly}
-	oninput={handleInput}
-	onfocus={handleFocus}
-	onmousedown={handleMouseDown}
-	onblur={handleBlur}
-	onkeydown={handleKeyDown}
+	isDisabled={ctx.isDisabled}
+	isReadOnly={ctx.isReadOnly}
+	oninput={composeEventHandlers(handleInput, onInputExternal ?? undefined)}
+	onfocus={composeEventHandlers(handleFocus, onFocusExternal ?? undefined)}
+	onmousedown={composeEventHandlers(handleMouseDown, onMouseDownExternal ?? undefined)}
+	onblur={composeEventHandlers(handleBlur, onBlurExternal ?? undefined)}
+	onkeydown={composeEventHandlers(handleKeyDown, onKeyDownExternal ?? undefined)}
 	class={cn(
 		'bg-depth-2 sunken placeholder:text-muted-foreground hover:bg-depth-1 focus:ring-border h-8 w-full rounded-xs border px-2 text-sm shadow-xs transition-all ease-out outline-none focus:ring focus:ring-offset-1 disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50',
 		className

--- a/packages/svelte/src/lib/combobox/input/combobox-input.test.ts
+++ b/packages/svelte/src/lib/combobox/input/combobox-input.test.ts
@@ -12,6 +12,13 @@ describe('ComboBox.Input', () => {
 			await expect.element(input).toBeInTheDocument();
 		});
 
+		it('renders through the shared Input primitive', async () => {
+			const screen = render(ComboBoxTest);
+			const input = screen.getByRole('combobox');
+
+			await expect.element(input).toHaveAttribute('data-input-root', 'true');
+		});
+
 		it('has aria-autocomplete="list"', async () => {
 			const screen = render(ComboBoxTest);
 			const input = screen.getByRole('combobox');


### PR DESCRIPTION
*   Refactor `ComboBox.Input` to render through the shared `Input` primitive.
*   Migrate `disabled` and `readonly` props to `isDisabled` and `isReadOnly` to align with the `Input` primitive API.
*   Introduce event handler composition to allow external event handlers to be passed through and executed alongside internal combobox logic.
*   Add a test to confirm `ComboBox.Input` correctly uses the `Input` primitive.
*   Preserve existing combobox behavior and accessibility semantics.