### PR TITLE
chore(release): add table fixes changeset

### DIFF
--- a/.changeset/late-dingos-splash.md
+++ b/.changeset/late-dingos-splash.md
@@ -1,0 +1,5 @@
+---
+'@human-kit/svelte-components': patch
+---
+
+Fix `Table` column sizing and ordering edge cases by keeping trailing flexible columns in sync during resize recovery, recomputing relative widths after viewport or container size changes, avoiding one-pixel width loss from relative-column rounding, and updating body cell column indices correctly when keyed columns reorder.


### PR DESCRIPTION
* Fix `Table` column sizing and ordering edge cases.
* Synchronize trailing flexible columns during resize recovery.
* Recompute relative widths after viewport or container size changes.
* Prevent one-pixel width loss from relative-column rounding.
* Correctly update body cell column indices when keyed columns reorder.