### PR TITLE
fix(release): don't pass --tag to changeset publish in pre mode

### DIFF
--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -1,27 +1,23 @@
-// Publishes packages with the correct npm dist-tag.
+// Publishes packages with changesets.
 //
-// `changeset publish` tags every release as `latest` unless you pass `--tag`.
-// That means prereleases (alpha/beta) would overwrite `latest`, so a plain
-// `npm install` pulls an unstable version. This script derives the tag from
-// changesets pre mode: while `.changeset/pre.json` exists we publish under its
-// tag (e.g. `beta`); once you exit pre mode the file is gone and we publish to
-// `latest` as normal.
+// The npm dist-tag is handled by changesets itself — do NOT pass `--tag`:
+//   - In prerelease mode (`.changeset/pre.json` present) `changeset publish`
+//     already publishes under the pre tag (e.g. `beta`), and passing an explicit
+//     `--tag` is REJECTED ("Releasing under custom tag is not allowed in pre
+//     mode"). This is the bug that broke the Release workflow.
+//   - In stable mode it publishes to `latest`, which is what we want.
+// So we just detect the mode for a helpful log line and run a plain publish.
 
 import { existsSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
 const preConfigUrl = new URL('../.changeset/pre.json', import.meta.url);
 
-let publishArgs = 'publish';
-
 if (existsSync(preConfigUrl)) {
 	const pre = JSON.parse(readFileSync(preConfigUrl, 'utf8'));
-	if (pre.mode === 'pre' && pre.tag) {
-		publishArgs += ` --tag ${pre.tag}`;
-		console.log(`Prerelease mode detected: publishing under npm dist-tag "${pre.tag}".`);
-	}
+	console.log(`Prerelease mode detected: changeset will publish under the "${pre.tag}" dist-tag.`);
 } else {
 	console.log('Stable mode: publishing under npm dist-tag "latest".');
 }
 
-execSync(`pnpm exec changeset ${publishArgs}`, { stdio: 'inherit' });
+execSync('pnpm exec changeset publish', { stdio: 'inherit' });


### PR DESCRIPTION
The Release workflow failed after merging #58 because `scripts/publish.mjs` passes `--tag beta` to `changeset publish`, which changesets rejects in prerelease mode:

```
error Releasing under custom tag is not allowed in pre mode
```

Changesets already publishes under the pre tag (`beta`) automatically in pre mode, so this removes the explicit `--tag` and just runs a plain `changeset publish` (which still uses `latest` in stable mode).

Scripts-only change — no library source touched.