### PR TITLE
fix(table): export the cell context from the table subpath

### DIFF
--- a/.changeset/table-cell-context-export.md
+++ b/.changeset/table-cell-context-export.md
@@ -1,0 +1,17 @@
+---
+'@human-kit/ui': patch
+---
+
+Export the table cell context, `TableRowItem` and `TableRowFocusEdge` from `@human-kit/ui/table`.
+
+`useTableCellContext` (and its `get`/`set` pair, plus the `TableCellContext` type) were defined
+alongside the table, row and column contexts but left out of the subpath's barrel. Every other
+level of the grid was reachable; the cell was the one that forced consumers to deep-import
+`table/root/context.svelte.js`, a path outside the package's `exports` map — so it typechecked
+only against the source, never against the published package.
+
+Two type-level gaps of the same kind are closed with it. `TableRowItem` is the constraint on the
+already-exported `TableBodyProps<T extends TableRowItem>`, and `TableRowFocusEdge` is the second
+parameter of `focusRowByToken` and `setFocusedRow` on the already-exported `TableContext`. Both
+were unnameable from outside the package, which made the surfaces that use them impossible to
+annotate or wrap.

--- a/packages/ui/src/lib/table/index.ts
+++ b/packages/ui/src/lib/table/index.ts
@@ -54,7 +54,12 @@ export {
 	getTableColumnContext,
 	setTableColumnContext,
 	useTableColumnContext,
+	getTableCellContext,
+	setTableCellContext,
+	useTableCellContext,
 	type TableContext,
+	type TableRowItem,
+	type TableRowFocusEdge,
 	type TableDisabledBehavior,
 	type TableSelectionBehavior,
 	type TableSelectionCheckboxState,
@@ -71,6 +76,7 @@ export {
 	type TableSectionContext,
 	type TableRowContext,
 	type TableColumnContext,
+	type TableCellContext,
 	type CreateTableContextOptions,
 	DEFAULT_TABLE_COLUMN_MIN_WIDTH
 } from './root/context.svelte';


### PR DESCRIPTION
`@human-kit/ui/table` re-exported the table, section, row and column contexts but not the cell one. Verified against the published `1.0.0-beta.1` tarball: `dist/table/index.js` stops at `useTableColumnContext`.

The workaround consumers were forced into — importing `@human-kit/ui/table/root/context.svelte.js` — is not a valid entry point. The file ships in `dist`, but the `exports` map has no wildcard, so that specifier is `ERR_PACKAGE_PATH_NOT_EXPORTED` under Node ESM, Vite, and TS `moduleResolution: "bundler"`. It only appeared to work because the workspace resolves to source and classic `node` resolution ignores `exports`.

## Changes

- Export `getTableCellContext` / `setTableCellContext` / `useTableCellContext` and the `TableCellContext` type from `table/index.ts`
- Export `TableRowItem` — the constraint on the already-exported `TableBodyProps<T extends TableRowItem>`
- Export `TableRowFocusEdge` — the second parameter of `focusRowByToken` and `setFocusedRow` on the already-exported `TableContext`

`distributeRoundedWidths` and `RoundedWidthDistributionEntry` were the only other unexported members of the context module; they stay internal, as column-width rounding math that appears in no exported signature.

Patch changeset included — releases as `1.0.0-beta.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)