### PR TITLE
chore: version packages (1.0.0-beta.2)

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -42,6 +42,7 @@
     "solid-input-basics",
     "stale-pets-cheer",
     "strong-cars-smell",
+    "table-cell-context-export",
     "tame-schools-share",
     "textarea-v1",
     "thin-turtles-allow",

--- a/docs/src/lib/docs/releases-data.json
+++ b/docs/src/lib/docs/releases-data.json
@@ -1,5 +1,21 @@
 [
 	{
+		"version": "1.0.0-beta.2",
+		"date": "2026-08-01T17:34:05.494Z",
+		"sections": [
+			{
+				"type": "Patch",
+				"entries": [
+					{
+						"pr": 64,
+						"prUrl": "https://github.com/human-kit/ui/pull/64",
+						"html": "<p>Export the table cell context, <code>TableRowItem</code> and <code>TableRowFocusEdge</code> from <code>@human-kit/ui/table</code>.</p>\n<p><code>useTableCellContext</code> (and its <code>get</code>/<code>set</code> pair, plus the <code>TableCellContext</code> type) were defined\nalongside the table, row and column contexts but left out of the subpath's barrel. Every other\nlevel of the grid was reachable; the cell was the one that forced consumers to deep-import\n<code>table/root/context.svelte.js</code>, a path outside the package's <code>exports</code> map — so it typechecked\nonly against the source, never against the published package.</p>\n<p>Two type-level gaps of the same kind are closed with it. <code>TableRowItem</code> is the constraint on the\nalready-exported <code>TableBodyProps&lt;T extends TableRowItem&gt;</code>, and <code>TableRowFocusEdge</code> is the second\nparameter of <code>focusRowByToken</code> and <code>setFocusedRow</code> on the already-exported <code>TableContext</code>. Both\nwere unnameable from outside the package, which made the surfaces that use them impossible to\nannotate or wrap.</p>"
+					}
+				]
+			}
+		]
+	},
+	{
 		"version": "1.0.0-beta.1",
 		"date": "2026-08-01T11:46:07-03:00",
 		"sections": [

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @human-kit/ui
 
+## 1.0.0-beta.2
+
+### Patch Changes
+
+- [#64](https://github.com/human-kit/ui/pull/64) [`5cf5441`](https://github.com/human-kit/ui/commit/5cf544138842fd0bf3861a1c3be2d1c6bfed0f62) Thanks [@Agustin-Delgado](https://github.com/Agustin-Delgado)! - Export the table cell context, `TableRowItem` and `TableRowFocusEdge` from `@human-kit/ui/table`.
+
+  `useTableCellContext` (and its `get`/`set` pair, plus the `TableCellContext` type) were defined
+  alongside the table, row and column contexts but left out of the subpath's barrel. Every other
+  level of the grid was reachable; the cell was the one that forced consumers to deep-import
+  `table/root/context.svelte.js`, a path outside the package's `exports` map — so it typechecked
+  only against the source, never against the published package.
+
+  Two type-level gaps of the same kind are closed with it. `TableRowItem` is the constraint on the
+  already-exported `TableBodyProps<T extends TableRowItem>`, and `TableRowFocusEdge` is the second
+  parameter of `focusRowByToken` and `setFocusedRow` on the already-exported `TableContext`. Both
+  were unnameable from outside the package, which made the surfaces that use them impossible to
+  annotate or wrap.
+
 ## 1.0.0-beta.1
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@human-kit/ui",
-	"version": "1.0.0-beta.1",
+	"version": "1.0.0-beta.2",
 	"description": "Accessible, typed UI components for Svelte 5 — shipped as native ESM with per-component subpath exports so bundlers only include what you import.",
 	"license": "MIT",
 	"author": "Agustin Delgado <agustindariodelgado@gmail.com>",


### PR DESCRIPTION
Generated by the `Release` workflow ([run](https://github.com/human-kit/ui/actions/runs/30710591695)) after #64 landed on `main`.

**Merging this publishes `@human-kit/ui@1.0.0-beta.2` to npm.**

## Contents

| File | |
|---|---|
| `packages/ui/package.json` | `1.0.0-beta.1` → `1.0.0-beta.2` |
| `packages/ui/CHANGELOG.md` | patch entry for the table subpath exports |
| `docs/src/lib/docs/releases-data.json` | new entry for the docs releases timeline |
| `.changeset/pre.json` | records `table-cell-context-export` as consumed |

No source changes — those shipped in #64.