### PR TITLE
ci(release): authenticate with npm before publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,21 @@ jobs:
             echo "Merging it publishes to npm."
           } >> "$GITHUB_STEP_SUMMARY"
 
+      # `changeset publish` authenticates through an `.npmrc`, and nothing else
+      # here writes one: the repo ships none, and `actions/setup-node` only
+      # generates one when given `registry-url`. `changesets/action` used to do
+      # this itself, which is why it was invisible until that action was dropped —
+      # an unauthenticated publish comes back as `E404 undefined`, because npm
+      # masks "you may not publish here" as "no such package".
+      #
+      # Written to $HOME rather than the workspace so it cannot be committed by a
+      # later step, and only on the branch that actually publishes.
+      - name: Authenticate with npm
+        if: steps.version.outputs.versioned == 'false'
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$HOME/.npmrc"
+
       # Only when there was nothing left to version — that is, the release branch
       # has been merged. `changeset publish` skips versions already on npm, so a
       # rerun is a no-op, and it recovers a release whose version commit landed


### PR DESCRIPTION
Fixes the `Publish` failure on [run 30710802801](https://github.com/human-kit/ui/actions/runs/30710802801). `1.0.0-beta.2` is versioned on `main` but never reached npm.

## Cause

`changeset publish` reads credentials from an `.npmrc`, and nothing in this workflow writes one:

- the repo ships no `.npmrc`
- `actions/setup-node` only generates one when passed `registry-url`, which this workflow does not pass
- `changesets/action` used to write it itself — this is the third thing it was doing implicitly, after the `GITHUB_TOKEN` the version step needs and the tag push

So the publish ran unauthenticated, and npm answered `E404 undefined`: it reports "you may not publish here" as "no such package", which is why the failure named no cause.

`NPM_TOKEN` was never the problem — the same secret published `beta.0` and `beta.1`.

## Fix

An `Authenticate with npm` step that writes `$HOME/.npmrc`, gated on the same condition as `Publish` so it never runs on the versioning path. `$HOME` rather than the workspace so no later step can commit it.

## After merge

The run takes the `versioned=false` path — no changesets pending — so `Publish` runs against the already-versioned `1.0.0-beta.2` and ships it, followed by the tag push. This is exactly the recovery the workflow comment describes: *"it recovers a release whose version commit landed but whose publish did not."*

🤖 Generated with [Claude Code](https://claude.com/claude-code)