### PR TITLE
feat(menu): add Menu.ContextTrigger

### DIFF
--- a/.changeset/menu-context-trigger.md
+++ b/.changeset/menu-context-trigger.md
@@ -1,0 +1,9 @@
+---
+'@human-kit/ui': minor
+---
+
+Add `Menu.ContextTrigger`, a surface that opens the menu on right click, on long press for touch and pen, and with `Shift+F10` or the `ContextMenu` key. Everything below the trigger — items, groups, submenus, keyboard navigation — is unchanged, so a context menu is the same menu with a different opener.
+
+The panel is anchored at the pointer (and `Menu.Content` drops its default `offset` to `0` for a context menu), or to the surface itself when opened from the keyboard, where no pointer position exists.
+
+Two new primitives back it and are exported for reuse: `createPointAnchor`, which lets any floating panel anchor to a viewport point instead of an element, and the `longPress` action.

--- a/docs/src/content/menu/api.json
+++ b/docs/src/content/menu/api.json
@@ -98,6 +98,86 @@
 			]
 		},
 		{
+			"name": "ContextTrigger",
+			"description": "A surface that opens the menu on right click, long press, or Shift+F10 — anchored at the pointer. Renders a plain element rather than a button, so it can wrap arbitrary content.",
+			"props": [
+				{
+					"name": "disabled",
+					"type": "boolean",
+					"required": false,
+					"default": "false",
+					"description": "Whether the surface is disabled. The browser's own context menu is left alone."
+				},
+				{
+					"name": "longPress",
+					"type": "boolean",
+					"required": false,
+					"default": "true",
+					"description": "Whether a long press opens the menu on touch and pen."
+				},
+				{
+					"name": "longPressDelay",
+					"type": "number",
+					"required": false,
+					"default": "LONG_PRESS_DELAY_MS",
+					"description": "How long a touch has to be held, in ms."
+				},
+				{
+					"name": "preventTouchCallout",
+					"type": "boolean",
+					"required": false,
+					"default": "true",
+					"description": "Whether to suppress the iOS text callout / selection on the surface. Long press\nis unusable there without it; turn it off if the surface contains text the user\nis meant to select."
+				},
+				{
+					"name": "tabindex",
+					"type": "number",
+					"required": false,
+					"default": "0",
+					"description": "Tab order position. Defaults to `0` so keyboard users can reach the surface and\nopen the menu with Shift+F10. Pass `-1` when the surface lives inside a composite\nthat already manages focus with a roving tabindex (a table, a tree)."
+				},
+				{
+					"name": "children",
+					"type": "Snippet",
+					"required": false,
+					"default": null,
+					"description": ""
+				},
+				{
+					"name": "class",
+					"type": "string",
+					"required": false,
+					"default": "''",
+					"description": ""
+				},
+				{
+					"name": "element",
+					"type": "HTMLElement | null",
+					"required": false,
+					"default": "null",
+					"description": ""
+				}
+			],
+			"dataAttributes": [
+				{
+					"name": "data-context-trigger",
+					"description": "Present on every context-menu surface."
+				},
+				{
+					"name": "data-disabled",
+					"description": "Present when the surface is disabled, leaving the browser's own menu in place."
+				},
+				{
+					"name": "data-menu-trigger",
+					"description": "Present on any element that opens a menu, context or not."
+				},
+				{
+					"name": "data-state",
+					"description": "`open` or `closed`."
+				}
+			]
+		},
+		{
 			"name": "Content",
 			"description": "The floating role=\"menu\" panel. Renders in a portal and positions itself against the trigger; also used as the panel of a submenu.",
 			"props": [
@@ -105,8 +185,8 @@
 					"name": "offset",
 					"type": "number",
 					"required": false,
-					"default": "4",
-					"description": "Offset along the main axis from the trigger element."
+					"default": null,
+					"description": "Offset along the main axis from the trigger element. Defaults to `4`, or to `0`\n for a context menu, which sits at the pointer like a native one."
 				},
 				{
 					"name": "placement",

--- a/docs/src/content/menu/demos/context.svelte
+++ b/docs/src/content/menu/demos/context.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+	import { Menu } from '@human-kit/ui';
+
+	let lastAction = $state('—');
+
+	const itemClass =
+		'flex cursor-default items-center px-2 py-1.5 text-sm text-neutral-700 outline-none ' +
+		'data-disabled:cursor-not-allowed data-disabled:opacity-40 data-highlighted:bg-neutral-900 ' +
+		'data-highlighted:text-white dark:text-neutral-200 dark:data-highlighted:bg-white ' +
+		'dark:data-highlighted:text-neutral-900';
+</script>
+
+<div class="flex flex-col items-center gap-3">
+	<Menu.Root>
+		<Menu.ContextTrigger
+			class="flex h-40 w-full max-w-sm items-center justify-center border border-dashed border-neutral-300 text-sm text-neutral-500 outline-none select-none focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-neutral-900 data-[state=open]:border-neutral-900 dark:border-neutral-700 dark:text-neutral-400 dark:focus-visible:outline-white dark:data-[state=open]:border-white"
+		>
+			Right click, long press, or press Shift+F10
+		</Menu.ContextTrigger>
+
+		<Menu.Content
+			class="min-w-44 border border-neutral-200 bg-white p-1 shadow-md dark:border-neutral-800 dark:bg-neutral-900"
+		>
+			<Menu.Item class={itemClass} onAction={() => (lastAction = 'Cut')}>Cut</Menu.Item>
+			<Menu.Item class={itemClass} onAction={() => (lastAction = 'Copy')}>Copy</Menu.Item>
+			<Menu.Item class={itemClass} onAction={() => (lastAction = 'Paste')}>Paste</Menu.Item>
+			<Menu.Separator class="my-1 h-px bg-neutral-200 dark:bg-neutral-800" />
+			<Menu.SubmenuRoot>
+				<Menu.SubmenuTrigger class={itemClass} value="more">Share</Menu.SubmenuTrigger>
+				<Menu.Content
+					class="min-w-40 border border-neutral-200 bg-white p-1 shadow-md dark:border-neutral-800 dark:bg-neutral-900"
+				>
+					<Menu.Item class={itemClass} onAction={() => (lastAction = 'Copy link')}>
+						Copy link
+					</Menu.Item>
+					<Menu.Item class={itemClass} onAction={() => (lastAction = 'Email')}>Email</Menu.Item>
+				</Menu.Content>
+			</Menu.SubmenuRoot>
+		</Menu.Content>
+	</Menu.Root>
+
+	<p class="text-sm text-neutral-500 dark:text-neutral-400">Last action: {lastAction}</p>
+</div>

--- a/docs/src/content/menu/index.md
+++ b/docs/src/content/menu/index.md
@@ -1,6 +1,6 @@
 ---
 title: Menu
-description: An accessible dropdown / action menu with arrow-key navigation, typeahead, groups, separators, and submenus.
+description: An accessible dropdown / action menu with arrow-key navigation, typeahead, groups, separators, submenus, and a context-menu trigger.
 ---
 
 <script>
@@ -11,6 +11,8 @@ description: An accessible dropdown / action menu with arrow-key navigation, typ
 	import groupsSource from './demos/groups.svelte?highlight';
 	import Submenu from './demos/submenu.svelte';
 	import submenuSource from './demos/submenu.svelte?highlight';
+	import Context from './demos/context.svelte';
+	import contextSource from './demos/context.svelte?highlight';
 	import api from './api.json';
 </script>
 
@@ -55,6 +57,22 @@ Nest a `Menu.SubmenuRoot` containing a `Menu.SubmenuTrigger` and its own `Menu.C
 
 <Demo source={submenuSource}><Submenu /></Demo>
 
+## Context menu
+
+Swap `Menu.Trigger` for `Menu.ContextTrigger` to open the menu from a surface instead of a button. Everything below the trigger — items, groups, submenus, keyboard navigation — is unchanged.
+
+<Demo source={contextSource}><Context /></Demo>
+
+`Menu.ContextTrigger` renders a plain element, not a button, so it can wrap arbitrary content. It opens three ways, and each anchors the panel differently:
+
+- **Right click** — at the pointer, flush against it: `Menu.Content` drops its default `offset` to `0` for a context menu, and unfolds down and to the right like a native one. Right clicking again re-anchors the open menu instead of closing and reopening it.
+- **Long press** on touch or pen — at the finger. This is what makes the menu reachable on a phone, where `contextmenu` is unreliable. The surface sets `-webkit-touch-callout: none; user-select: none` inline so iOS raises the menu rather than the text callout; opt out with `preventTouchCallout={false}`, or turn the gesture off entirely with `longPress={false}`.
+- **`Shift+F10` or the `ContextMenu` key** — anchored to the surface itself, with the first item focused. There is no pointer, so reusing the last cursor position would put the panel somewhere the keyboard user never pointed at.
+
+A left press anywhere — including on the surface itself — dismisses it, like a native menu.
+
+For a list where every row has the same menu, give each row its own `Menu.Root`: state is per-root, so the row that was right-clicked is the one the menu belongs to.
+
 ## Usage guidelines
 
 - Use `Menu.Root` to share open state and the trigger reference, and place `Menu.Trigger` and `Menu.Content` inside it.
@@ -70,6 +88,8 @@ Nest a `Menu.SubmenuRoot` containing a `Menu.SubmenuTrigger` and its own `Menu.C
 - `Menu.Content` renders `role="menu"` and items render `role="menuitem"`; arrow keys move the highlight, and typeahead focuses items by typed text.
 - Escape closes the current (topmost) menu and returns focus to its trigger; `Tab` and outside interaction close the whole menu chain.
 - Within a submenu, `ArrowLeft` closes just that level; `ArrowRight` on a submenu trigger opens it.
+- `Menu.ContextTrigger` is a tab stop by default (`tabindex={0}`) so a keyboard user can reach it and press `Shift+F10`; pass `tabindex={-1}` when it sits inside a composite that already manages focus with a roving tabindex, such as a table or a tree.
+- The surface carries `aria-keyshortcuts="Shift+F10"` and nothing else: `aria-haspopup` and `aria-expanded` are not global ARIA properties, so on a generic element they would be invalid. That is a real limit — **a context menu must never be the only route to an action.** Give the same `Menu.Root` a visible `Menu.Trigger`, or expose the same actions elsewhere.
 
 ## API reference
 

--- a/packages/ui/src/lib/FOCUS_STATE_CONTRACT.md
+++ b/packages/ui/src/lib/FOCUS_STATE_CONTRACT.md
@@ -57,6 +57,7 @@ The following components implement this contract:
 - **Popover** — trigger + content, restore focus on close.
 - **Dialog** — trigger + overlay/content, nested stack support.
 - **Drawer** — trigger + overlay/content, shares the modal layer stack with Dialog. Restore also covers the `swipe` close reason (resolves to `pointer`), and retries the trigger focus after `ariaHideOutside` lifts `inert`.
+- **Menu** — trigger + content, restore focus on close (`menu/root/focus-state.ts`). `Menu.ContextTrigger` is the same contract on a surface instead of a button: it registers as the trigger ref, so Escape and item selection restore focus to it. It is a tab stop by default so there is something to restore focus to.
 - **DatePicker** — segment spinbuttons, trigger, popover (calendar).
 - **TimePicker** — segment spinbuttons, trigger, popover (scrollable columns). Follows the same contract as DatePicker.
 - **Calendar** — grid cells with roving tabindex.

--- a/packages/ui/src/lib/menu/README.md
+++ b/packages/ui/src/lib/menu/README.md
@@ -12,6 +12,8 @@ primitives as `Popover`.
 - Use `Menu.Root` to share open state and the trigger reference.
 - Use `Menu.Trigger` as the opener button. `ArrowDown`/`Enter`/`Space` open the menu and focus the
   first item; `ArrowUp` opens and focuses the last item.
+- Use `Menu.ContextTrigger` instead of `Menu.Trigger` to open the menu from a surface rather than
+  a button: right click, long press on touch, or `Shift+F10` / the `ContextMenu` key.
 - Use `Menu.Content` inside `Menu.Root`. It renders the `role="menu"` panel in a portal and
   positions it against the trigger (default placement `bottom-start`).
 - Use `Menu.Item` for actions. Provide `onAction`, and optionally `disabled`, `closeOnSelect`, or
@@ -33,6 +35,38 @@ primitives as `Popover`.
   open submenu, hovering the sibling items it passes over does not close the submenu for a short
   grace period, so the user can reach it without the submenu collapsing mid-path.
 
+## Context menus
+
+`Menu.ContextTrigger` is a surface, not a button: it renders a plain element so it can wrap
+arbitrary — sometimes interactive — content. It opens the menu three ways, and each anchors the
+panel differently:
+
+- **Right click** — anchored at the pointer, flush against it (`Menu.Content` drops its default
+  `offset` to `0` for a context menu), unfolding down and to the right like a native one. Right
+  clicking again re-anchors the open menu instead of closing and reopening it.
+- **Long press** on touch or pen — anchored at the finger. It is what makes the menu reachable at
+  all on a phone, where `contextmenu` is unreliable. The action suppresses the `click` and
+  `contextmenu` the platform emits for the same gesture, and the surface sets
+  `-webkit-touch-callout: none; user-select: none` inline so iOS raises the menu instead of the
+  text callout. Turn either off with `longPress={false}` / `preventTouchCallout={false}`.
+- **`Shift+F10` or the `ContextMenu` key** — anchored to the surface itself, with the first item
+  focused. There is no pointer involved, so reusing the last cursor position would put the panel
+  somewhere the keyboard user never pointed at.
+
+A left press anywhere — including on the surface itself — dismisses it, like a native menu.
+
+### Accessibility
+
+The surface is a tab stop by default (`tabindex={0}`) so a keyboard user can reach it; pass
+`tabindex={-1}` when it lives inside a composite that already manages focus with a roving
+tabindex, such as a table or a tree.
+
+It carries `aria-keyshortcuts="Shift+F10"` and nothing else. `aria-haspopup` and `aria-expanded`
+are **not** global ARIA properties: on a generic element they would be invalid, so the component
+does not claim them. That is a real limit, not an oversight — **a context menu must never be the
+only route to an action.** Give the same `Menu.Root` a visible `Menu.Trigger`, or expose the same
+actions elsewhere in the UI.
+
 ## onOpenChange details
 
 `Menu.Root` and `Menu.SubmenuRoot` use:
@@ -46,6 +80,17 @@ primitives as `Popover`.
 ## Anatomy
 
 Import the component and compose its parts:
+
+A context menu swaps the trigger and keeps everything else:
+
+```svelte
+<Menu.Root>
+	<Menu.ContextTrigger>Right click anywhere in this card</Menu.ContextTrigger>
+	<Menu.Content>
+		<Menu.Item onAction={edit}>Edit</Menu.Item>
+	</Menu.Content>
+</Menu.Root>
+```
 
 ```svelte
 <Menu.Root>
@@ -74,6 +119,7 @@ Import the component and compose its parts:
 
 - `Menu.Root`
 - `Menu.Trigger`
+- `Menu.ContextTrigger`
 - `Menu.Content`
 - `Menu.Item`
 - `Menu.Separator`

--- a/packages/ui/src/lib/menu/content/menu-content.svelte
+++ b/packages/ui/src/lib/menu/content/menu-content.svelte
@@ -3,7 +3,7 @@
 	import type { HTMLAttributes } from 'svelte/elements';
 	import { onDestroy, tick } from 'svelte';
 	import { browser } from '../../internal/environment';
-	import { floating, type ExtendedPlacement } from '../../primitives/floating';
+	import { createPointAnchor, floating, type ExtendedPlacement } from '../../primitives/floating';
 	import { clickOutside, isTargetInTopLayerAbove } from '../../primitives/click-outside';
 	import { scrollLock } from '../../primitives/scroll-lock';
 	import { releaseFocusedDescendant } from '../../primitives/release-focused-descendant';
@@ -18,7 +18,8 @@
 	 * Rendered in a Portal, positioned against the trigger.
 	 */
 	type MenuContentProps = {
-		/** Offset along the main axis from the trigger element. */
+		/** Offset along the main axis from the trigger element. Defaults to `4`, or to `0`
+		 *  for a context menu, which sits at the pointer like a native one. */
 		offset?: number;
 		/** Placement relative to the trigger element. Defaults to `bottom-start`
 		 *  for a root menu and `right-start` for a submenu. */
@@ -38,7 +39,7 @@
 	} & Omit<HTMLAttributes<HTMLDivElement>, 'class' | 'children' | 'role'>;
 
 	let {
-		offset = 4,
+		offset,
 		placement,
 		shouldFlip = true,
 		boundaryElement = null,
@@ -55,6 +56,16 @@
 	const triggerRef = $derived(ctx.triggerRef);
 	const resolvedPlacementProp = $derived(
 		placement ?? (ctx.parent ? 'right-start' : 'bottom-start')
+	);
+	// A context menu opens AT the pointer, so the anchor is a zero-size point rather than
+	// the surface, and it sits flush against it — the 4px gap a dropdown keeps from its
+	// button would read as the panel drifting away from the cursor. The default placement
+	// (`bottom-start`) already matches how a native context menu unfolds down and to the
+	// right, and `flip`/`shift` handle the viewport edges.
+	const resolvedOffset = $derived(offset ?? (ctx.isContextMenu ? 0 : 4));
+	const anchorPoint = $derived(ctx.anchorPoint);
+	const resolvedAnchor = $derived(
+		anchorPoint ? createPointAnchor(anchorPoint.x, anchorPoint.y, triggerRef) : triggerRef
 	);
 
 	let menuRef: HTMLElement | undefined = $state();
@@ -261,8 +272,8 @@
 			data-exiting={presence.isExiting || undefined}
 			data-placement={resolvedPlacement}
 			use:floating={{
-				anchor: triggerRef,
-				offset,
+				anchor: resolvedAnchor,
+				offset: resolvedOffset,
 				placement: resolvedPlacementProp,
 				shouldFlip,
 				boundaryElement,

--- a/packages/ui/src/lib/menu/context-trigger/menu-context-trigger-ssr.test.ts
+++ b/packages/ui/src/lib/menu/context-trigger/menu-context-trigger-ssr.test.ts
@@ -1,0 +1,35 @@
+// @vitest-environment node
+
+import { describe, expect, it } from 'vitest';
+import { render } from 'svelte/server';
+import MenuContextTriggerTest from './menu-context-trigger-test.svelte';
+
+function getSurfaceTag(source: string) {
+	const markerIndex = source.indexOf('data-context-trigger="true"');
+	const tagStart = source.lastIndexOf('<', markerIndex);
+	const tagEnd = source.indexOf('>', markerIndex);
+
+	if (markerIndex === -1 || tagStart === -1 || tagEnd === -1) return '';
+	return source.slice(tagStart, tagEnd + 1);
+}
+
+describe('Menu.ContextTrigger SSR', () => {
+	it('renders the surface on the server without touching the DOM', () => {
+		const { body } = render(MenuContextTriggerTest);
+		const surface = getSurfaceTag(body);
+
+		expect(surface).toContain('tabindex="0"');
+		expect(surface).toContain('data-state="closed"');
+		expect(surface).toContain('aria-keyshortcuts="Shift+F10"');
+		// The panel only exists once the menu opens, which is a client-side event.
+		expect(body).not.toContain('role="menu"');
+	});
+
+	it('marks a disabled surface and drops its shortcut', () => {
+		const { body } = render(MenuContextTriggerTest, { props: { disabled: true } });
+		const surface = getSurfaceTag(body);
+
+		expect(surface).toContain('data-disabled="true"');
+		expect(surface).not.toContain('aria-keyshortcuts');
+	});
+});

--- a/packages/ui/src/lib/menu/context-trigger/menu-context-trigger-test.svelte
+++ b/packages/ui/src/lib/menu/context-trigger/menu-context-trigger-test.svelte
@@ -1,0 +1,49 @@
+<script lang="ts">
+	import { Menu } from '../index';
+	import type { MenuOpenChangeDetails } from '../root/context';
+
+	type Props = {
+		disabled?: boolean;
+		longPress?: boolean;
+		longPressDelay?: number;
+		withSubmenu?: boolean;
+		onAction?: (value: string) => void;
+		onOpenChange?: (open: boolean, details: MenuOpenChangeDetails) => void;
+	};
+
+	let {
+		disabled = false,
+		longPress = true,
+		longPressDelay,
+		withSubmenu = false,
+		onAction,
+		onOpenChange
+	}: Props = $props();
+</script>
+
+<Menu.Root {onOpenChange}>
+	<Menu.ContextTrigger
+		{disabled}
+		{longPress}
+		{longPressDelay}
+		style="width: 200px; height: 120px; margin: 24px;"
+	>
+		Right click here
+	</Menu.ContextTrigger>
+	<Menu.Content>
+		<Menu.Item value="edit" onAction={() => onAction?.('edit')}>Edit</Menu.Item>
+		<Menu.Item value="duplicate" onAction={() => onAction?.('duplicate')}>Duplicate</Menu.Item>
+
+		{#if withSubmenu}
+			<Menu.SubmenuRoot>
+				<Menu.SubmenuTrigger value="more">More actions</Menu.SubmenuTrigger>
+				<Menu.Content>
+					<Menu.Item value="archive" onAction={() => onAction?.('archive')}>Archive</Menu.Item>
+				</Menu.Content>
+			</Menu.SubmenuRoot>
+		{/if}
+	</Menu.Content>
+</Menu.Root>
+
+<!-- Somewhere outside the surface to click, and a second focus target. -->
+<button type="button">Outside</button>

--- a/packages/ui/src/lib/menu/context-trigger/menu-context-trigger.svelte
+++ b/packages/ui/src/lib/menu/context-trigger/menu-context-trigger.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+	import type { Snippet } from 'svelte';
+	import type { HTMLAttributes } from 'svelte/elements';
+	import { onDestroy, untrack } from 'svelte';
+	import { longPress, LONG_PRESS_DELAY_MS } from '../../primitives/long-press';
+	import { useMenuContext } from '../root/context';
+
+	/**
+	 * Menu.ContextTrigger - A surface that opens the menu on right click, long press,
+	 * or the platform's context-menu keystroke, anchored at the pointer.
+	 *
+	 * Unlike Menu.Trigger it renders a plain element rather than a button: it wraps
+	 * arbitrary — sometimes interactive — content, so it must not claim button
+	 * semantics.
+	 */
+	export type MenuContextTriggerProps = {
+		/** Whether the surface is disabled. The browser's own context menu is left alone. */
+		disabled?: boolean;
+		/** Whether a long press opens the menu on touch and pen. */
+		longPress?: boolean;
+		/** How long a touch has to be held, in ms. */
+		longPressDelay?: number;
+		/**
+		 * Whether to suppress the iOS text callout / selection on the surface. Long press
+		 * is unusable there without it; turn it off if the surface contains text the user
+		 * is meant to select.
+		 */
+		preventTouchCallout?: boolean;
+		/**
+		 * Tab order position. Defaults to `0` so keyboard users can reach the surface and
+		 * open the menu with Shift+F10. Pass `-1` when the surface lives inside a composite
+		 * that already manages focus with a roving tabindex (a table, a tree).
+		 */
+		tabindex?: number;
+		children?: Snippet;
+		class?: string;
+		element?: HTMLElement | null;
+	} & Omit<HTMLAttributes<HTMLDivElement>, 'class' | 'children' | 'tabindex'>;
+
+	let {
+		disabled = false,
+		longPress: longPressEnabled = true,
+		longPressDelay = LONG_PRESS_DELAY_MS,
+		preventTouchCallout = true,
+		tabindex = 0,
+		children,
+		class: className = '',
+		element = $bindable<HTMLElement | null>(null),
+		style: styleExternal,
+		oncontextmenu: onContextMenuExternal,
+		onkeydown: onKeydownExternal,
+		onpointerdown: onPointerDownExternal,
+		...restProps
+	}: MenuContextTriggerProps = $props();
+
+	const ctx = useMenuContext('Menu.ContextTrigger');
+
+	let surfaceRef: HTMLElement | null = $state(null);
+
+	/**
+	 * A `contextmenu` event the browser may synthesize right after we already handled
+	 * the keystroke ourselves — some browsers raise it on keyup, past our
+	 * `preventDefault`. It carries no useful coordinates, so letting it through would
+	 * re-anchor the open menu to the viewport origin. The window is short and always
+	 * released, so a genuine right click a moment later is never swallowed.
+	 */
+	let ignoreNextContextMenu = false;
+	let ignoreContextMenuTimer: ReturnType<typeof setTimeout> | null = null;
+
+	const SYNTHETIC_CONTEXT_MENU_WINDOW_MS = 100;
+
+	function releaseSyntheticContextMenu() {
+		ignoreNextContextMenu = false;
+		if (ignoreContextMenuTimer === null) return;
+		clearTimeout(ignoreContextMenuTimer);
+		ignoreContextMenuTimer = null;
+	}
+
+	function ignoreSyntheticContextMenu() {
+		releaseSyntheticContextMenu();
+		ignoreNextContextMenu = true;
+		ignoreContextMenuTimer = setTimeout(
+			releaseSyntheticContextMenu,
+			SYNTHETIC_CONTEXT_MENU_WINDOW_MS
+		);
+	}
+
+	onDestroy(releaseSyntheticContextMenu);
+
+	const styleValue = $derived(
+		[
+			// Both are needed for long press on iOS: without them the press raises the
+			// text callout and selection handles instead.
+			preventTouchCallout ? '-webkit-touch-callout: none; user-select: none;' : '',
+			styleExternal ?? ''
+		]
+			.filter(Boolean)
+			.join(' ')
+	);
+
+	function openAtPoint(x: number, y: number, event: Event) {
+		ctx.setAnchorPoint({ x, y });
+		// Already open (a second right click elsewhere on the surface): the point above
+		// re-anchors it, and `open` is a no-op that reports nothing to the consumer.
+		ctx.open('trigger-press', event);
+	}
+
+	function handleContextMenu(event: MouseEvent & { currentTarget: EventTarget & HTMLDivElement }) {
+		if (!disabled) {
+			// Always suppress the browser's menu when this surface owns one — otherwise
+			// both appear stacked.
+			event.preventDefault();
+			if (ignoreNextContextMenu) {
+				releaseSyntheticContextMenu();
+			} else {
+				openAtPoint(event.clientX, event.clientY, event);
+			}
+		}
+		onContextMenuExternal?.(event);
+	}
+
+	function handleKeydown(event: KeyboardEvent & { currentTarget: EventTarget & HTMLDivElement }) {
+		// Shift+F10 everywhere, plus the dedicated key on keyboards that have one.
+		const isContextMenuKey = event.key === 'ContextMenu' || (event.shiftKey && event.key === 'F10');
+		if (!disabled && isContextMenuKey && !ctx.isOpen) {
+			event.preventDefault();
+			ignoreSyntheticContextMenu();
+			// Anchor to the surface itself: there is no pointer, and a stale cursor
+			// position would put the menu somewhere the keyboard user never pointed at.
+			ctx.setAnchorPoint(null);
+			ctx.requestOpenFocus('first');
+			ctx.open('trigger-press', event);
+		}
+		onKeydownExternal?.(event);
+	}
+
+	function handlePointerDown(
+		event: PointerEvent & { currentTarget: EventTarget & HTMLDivElement }
+	) {
+		// A left click anywhere dismisses a context menu, including on its own surface.
+		// `Menu.Content` tells `clickOutside` to ignore the trigger — which is right for a
+		// button that toggles — so the surface has to close itself. Only for the mouse:
+		// on touch this same press is the start of the long press that opens it.
+		if (event.pointerType === 'mouse' && event.button === 0 && ctx.isOpen) {
+			ctx.close('outside-press', event);
+		}
+		onPointerDownExternal?.(event);
+	}
+
+	// `untrack` keeps the shared trigger ref out of this effect's dependencies — the
+	// cleanup writes it to null and the body back to the node, which would otherwise loop.
+	$effect(() => {
+		const node = surfaceRef;
+		element = node;
+		if (node) {
+			untrack(() => {
+				ctx.setTriggerRef(node);
+				ctx.setContextMenu(true);
+			});
+		}
+		return () => {
+			// Drop the stale ref on unmount so no close path tries to refocus a removed node.
+			untrack(() => {
+				if (node && ctx.triggerRef === node) {
+					ctx.setTriggerRef(null);
+					ctx.setContextMenu(false);
+				}
+			});
+		};
+	});
+</script>
+
+<!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+<div
+	bind:this={surfaceRef}
+	class={className}
+	{tabindex}
+	data-menu-trigger="true"
+	data-context-trigger="true"
+	data-state={ctx.isOpen ? 'open' : 'closed'}
+	data-disabled={disabled || undefined}
+	aria-keyshortcuts={disabled ? undefined : 'Shift+F10'}
+	style={styleValue || undefined}
+	oncontextmenu={handleContextMenu}
+	onkeydown={handleKeydown}
+	onpointerdown={handlePointerDown}
+	use:longPress={{
+		enabled: longPressEnabled && !disabled,
+		delay: longPressDelay,
+		onLongPress: (point, event) => openAtPoint(point.x, point.y, event)
+	}}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/packages/ui/src/lib/menu/context-trigger/menu-context-trigger.test.ts
+++ b/packages/ui/src/lib/menu/context-trigger/menu-context-trigger.test.ts
@@ -1,0 +1,267 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
+import MenuContextTriggerTest from './menu-context-trigger-test.svelte';
+import { expectNoFalseFocusAttributes } from '../../test-utils/focus-contract';
+
+function queryMenu() {
+	return document.querySelector('[role="menu"]') as HTMLElement | null;
+}
+
+function queryOpenMenu() {
+	return document.querySelector('[role="menu"][data-state="open"]') as HTMLElement | null;
+}
+
+function surface() {
+	return document.querySelector('[data-context-trigger]') as HTMLElement;
+}
+
+/** Right click at a viewport point, reporting whether the browser's own menu was suppressed. */
+function rightClick(node: Element, x: number, y: number) {
+	const event = new MouseEvent('contextmenu', {
+		bubbles: true,
+		cancelable: true,
+		button: 2,
+		clientX: x,
+		clientY: y
+	});
+	node.dispatchEvent(event);
+	return { defaultPrevented: event.defaultPrevented };
+}
+
+function pointerDown(node: Element, init: PointerEventInit = {}) {
+	node.dispatchEvent(
+		new PointerEvent('pointerdown', {
+			bubbles: true,
+			pointerId: 1,
+			pointerType: 'mouse',
+			isPrimary: true,
+			button: 0,
+			...init
+		})
+	);
+}
+
+describe('Menu.ContextTrigger', () => {
+	afterEach(() => {
+		document.querySelectorAll('[role="menu"]').forEach((menu) => menu.remove());
+	});
+
+	describe('pointer', () => {
+		it('opens at the point of the right click and suppresses the native menu', async () => {
+			render(MenuContextTriggerTest);
+
+			const { defaultPrevented } = rightClick(surface(), 120, 90);
+			expect(defaultPrevented).toBe(true);
+
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+			// Anchored at the pointer with no offset, unfolding down and to the right.
+			await expect.poll(() => queryMenu()!.getBoundingClientRect().left).toBeCloseTo(120, 0);
+			expect(queryMenu()!.getBoundingClientRect().top).toBeCloseTo(90, 0);
+		});
+
+		it('re-anchors when the surface is right clicked again, without closing', async () => {
+			const onOpenChange = vi.fn();
+			render(MenuContextTriggerTest, { onOpenChange });
+
+			rightClick(surface(), 40, 40);
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+
+			rightClick(surface(), 150, 130);
+			await expect.poll(() => queryMenu()!.getBoundingClientRect().left).toBeCloseTo(150, 0);
+
+			expect(queryOpenMenu()).toBeTruthy();
+			// One transition, not a close/reopen pair.
+			expect(onOpenChange).toHaveBeenCalledTimes(1);
+		});
+
+		it('closes on a left press on its own surface, like a native menu', async () => {
+			render(MenuContextTriggerTest);
+
+			rightClick(surface(), 60, 60);
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+
+			pointerDown(surface());
+			await expect.poll(() => queryOpenMenu()).toBeNull();
+		});
+
+		it('closes on a press outside', async () => {
+			const screen = render(MenuContextTriggerTest);
+
+			rightClick(surface(), 60, 60);
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+
+			await screen.getByRole('button', { name: 'Outside' }).click();
+			await expect.poll(() => queryOpenMenu()).toBeNull();
+		});
+
+		it('leaves the browser menu alone when disabled', async () => {
+			render(MenuContextTriggerTest, { disabled: true });
+
+			const { defaultPrevented } = rightClick(surface(), 60, 60);
+
+			expect(defaultPrevented).toBe(false);
+			expect(queryMenu()).toBeNull();
+		});
+	});
+
+	describe('keyboard', () => {
+		it('opens with Shift+F10 anchored to the surface, first item focused', async () => {
+			render(MenuContextTriggerTest);
+
+			// Park the real pointer on the surface: left where a previous test dropped it,
+			// it can end up over the panel and hover-highlight an item out from under the
+			// keyboard's first-item focus.
+			await userEvent.hover(surface());
+			surface().focus();
+			await userEvent.keyboard('{Shift>}{F10}{/Shift}');
+
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+			await expect
+				.poll(() =>
+					document.querySelector('[role="menuitem"][data-highlighted]')?.textContent?.trim()
+				)
+				.toBe('Edit');
+
+			// No pointer was involved, so the panel hangs off the surface itself.
+			await expect
+				.poll(() => queryMenu()!.getBoundingClientRect().left)
+				.toBeCloseTo(surface().getBoundingClientRect().left, 0);
+			expect(queryMenu()!.getBoundingClientRect().top).toBeGreaterThanOrEqual(
+				surface().getBoundingClientRect().bottom - 1
+			);
+		});
+
+		it('opens with the dedicated ContextMenu key', async () => {
+			render(MenuContextTriggerTest);
+
+			surface().focus();
+			await userEvent.keyboard('{ContextMenu}');
+
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+		});
+
+		it('closes on Escape and returns focus to the surface', async () => {
+			render(MenuContextTriggerTest);
+
+			surface().focus();
+			await userEvent.keyboard('{Shift>}{F10}{/Shift}');
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+
+			await userEvent.keyboard('{Escape}');
+			await expect.poll(() => queryOpenMenu()).toBeNull();
+			await expect.poll(() => document.activeElement).toBe(surface());
+		});
+
+		it('is reachable with the keyboard and announces its shortcut', async () => {
+			render(MenuContextTriggerTest);
+
+			expect(surface()).toHaveAttribute('tabindex', '0');
+			expect(surface()).toHaveAttribute('aria-keyshortcuts', 'Shift+F10');
+			// A generic element cannot carry aria-expanded / aria-haspopup: they are not
+			// global ARIA properties, and claiming them here would be invalid.
+			expect(surface()).not.toHaveAttribute('aria-expanded');
+		});
+
+		it('does not open while disabled', async () => {
+			render(MenuContextTriggerTest, { disabled: true });
+
+			surface().focus();
+			await userEvent.keyboard('{Shift>}{F10}{/Shift}');
+
+			expect(queryMenu()).toBeNull();
+		});
+	});
+
+	describe('touch', () => {
+		const LONG_PRESS_DELAY = 40;
+
+		function touch(node: Element, type: string, init: PointerEventInit = {}) {
+			node.dispatchEvent(
+				new PointerEvent(type, {
+					bubbles: true,
+					pointerId: 5,
+					pointerType: 'touch',
+					isPrimary: true,
+					button: 0,
+					...init
+				})
+			);
+		}
+
+		it('opens on a long press at the point of the finger', async () => {
+			render(MenuContextTriggerTest, { longPressDelay: LONG_PRESS_DELAY });
+
+			touch(surface(), 'pointerdown', { clientX: 70, clientY: 80 });
+
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+			const rect = queryMenu()!.getBoundingClientRect();
+			expect(rect.left).toBeCloseTo(70, 0);
+			expect(rect.top).toBeCloseTo(80, 0);
+		});
+
+		it('does not open when the finger travels — that gesture is a scroll', async () => {
+			render(MenuContextTriggerTest, { longPressDelay: LONG_PRESS_DELAY });
+
+			touch(surface(), 'pointerdown', { clientX: 70, clientY: 80 });
+			window.dispatchEvent(
+				new PointerEvent('pointermove', {
+					pointerId: 5,
+					pointerType: 'touch',
+					isPrimary: true,
+					clientX: 70,
+					clientY: 140
+				})
+			);
+
+			await new Promise((resolve) => setTimeout(resolve, LONG_PRESS_DELAY * 3));
+			expect(queryMenu()).toBeNull();
+		});
+
+		it('does not open on a long press when long press is off', async () => {
+			render(MenuContextTriggerTest, { longPress: false, longPressDelay: LONG_PRESS_DELAY });
+
+			touch(surface(), 'pointerdown', { clientX: 70, clientY: 80 });
+
+			await new Promise((resolve) => setTimeout(resolve, LONG_PRESS_DELAY * 3));
+			expect(queryMenu()).toBeNull();
+		});
+	});
+
+	describe('menu behaviour is unchanged', () => {
+		it('runs an item action and closes', async () => {
+			const onAction = vi.fn();
+			const screen = render(MenuContextTriggerTest, { onAction });
+
+			rightClick(surface(), 60, 60);
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+
+			await screen.getByRole('menuitem', { name: 'Edit' }).click();
+
+			expect(onAction).toHaveBeenCalledWith('edit');
+			await expect.poll(() => queryOpenMenu()).toBeNull();
+		});
+
+		it('opens a submenu from a context menu', async () => {
+			const screen = render(MenuContextTriggerTest, { withSubmenu: true });
+
+			rightClick(surface(), 60, 60);
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+
+			await screen.getByRole('menuitem', { name: 'More actions' }).click();
+			await expect.poll(() => document.querySelectorAll('[role="menu"]').length).toBe(2);
+		});
+
+		it('never reports a false focus state', async () => {
+			render(MenuContextTriggerTest);
+
+			rightClick(surface(), 60, 60);
+			await expect.poll(() => queryOpenMenu()).toBeTruthy();
+			expectNoFalseFocusAttributes();
+
+			pointerDown(surface());
+			await expect.poll(() => queryOpenMenu()).toBeNull();
+			expectNoFalseFocusAttributes();
+		});
+	});
+});

--- a/packages/ui/src/lib/menu/index.parts.ts
+++ b/packages/ui/src/lib/menu/index.parts.ts
@@ -1,6 +1,7 @@
 // Namespace parts for <Menu.Root>, <Menu.Content>, etc.
 export { default as Root } from './root/menu-root.svelte';
 export { default as Trigger } from './trigger/menu-trigger.svelte';
+export { default as ContextTrigger } from './context-trigger/menu-context-trigger.svelte';
 export { default as Content } from './content/menu-content.svelte';
 export { default as Overlay } from './overlay/menu-overlay.svelte';
 export { default as Item } from './item/menu-item.svelte';

--- a/packages/ui/src/lib/menu/index.ts
+++ b/packages/ui/src/lib/menu/index.ts
@@ -1,6 +1,7 @@
 import type { ComponentProps } from 'svelte';
 import type MenuRootComponent from './root/menu-root.svelte';
 import type MenuTriggerComponent from './trigger/menu-trigger.svelte';
+import type MenuContextTriggerComponent from './context-trigger/menu-context-trigger.svelte';
 import type MenuContentComponent from './content/menu-content.svelte';
 import type MenuOverlayComponent from './overlay/menu-overlay.svelte';
 import type MenuItemComponent from './item/menu-item.svelte';
@@ -16,6 +17,7 @@ export * as Menu from './index.parts.js';
 // Direct named exports for individual imports
 export { default as MenuRoot } from './root/menu-root.svelte';
 export { default as MenuTrigger } from './trigger/menu-trigger.svelte';
+export { default as MenuContextTrigger } from './context-trigger/menu-context-trigger.svelte';
 export { default as MenuContent } from './content/menu-content.svelte';
 export { default as MenuOverlay } from './overlay/menu-overlay.svelte';
 export { default as MenuItem } from './item/menu-item.svelte';
@@ -26,6 +28,7 @@ export { default as MenuSubmenuRoot } from './submenu/menu-submenu-root.svelte';
 export { default as MenuSubmenuTrigger } from './submenu/menu-submenu-trigger.svelte';
 export type MenuRootProps = ComponentProps<typeof MenuRootComponent>;
 export type MenuTriggerProps = ComponentProps<typeof MenuTriggerComponent>;
+export type MenuContextTriggerProps = ComponentProps<typeof MenuContextTriggerComponent>;
 export type MenuContentProps = ComponentProps<typeof MenuContentComponent>;
 export type MenuOverlayProps = ComponentProps<typeof MenuOverlayComponent>;
 export type MenuItemProps = ComponentProps<typeof MenuItemComponent>;
@@ -40,6 +43,7 @@ export {
 	getMenuContext,
 	setMenuContext,
 	useMenuContext,
+	type MenuAnchorPoint,
 	type MenuContext,
 	type MenuItemData,
 	type MenuCanonicalCloseReason,

--- a/packages/ui/src/lib/menu/root/context.ts
+++ b/packages/ui/src/lib/menu/root/context.ts
@@ -24,6 +24,9 @@ export type MenuChangeReason = MenuOpenReason | MenuCloseReason;
 /** Where focus should land when the menu content opens. */
 export type MenuOpenFocusIntent = 'first' | 'last';
 
+/** A viewport point (`clientX`/`clientY`) the content can be anchored to instead of an element. */
+export type MenuAnchorPoint = { x: number; y: number };
+
 export type MenuOpenChangeDetails = {
 	reason: MenuChangeReason;
 	event?: Event;
@@ -59,6 +62,16 @@ export type MenuContext = {
 	/** Reference to the content (role="menu") element. */
 	contentRef: HTMLElement | null;
 
+	/**
+	 * Viewport point the content should be anchored to, or `null` to anchor to the
+	 * trigger element. Set by `Menu.ContextTrigger` from the pointer that opened the
+	 * menu; a keyboard open clears it so the panel lands on the surface itself
+	 * rather than wherever the pointer happened to be.
+	 */
+	anchorPoint: MenuAnchorPoint | null;
+	/** Whether this menu is opened as a context menu (right click / long press). */
+	isContextMenu: boolean;
+
 	/** Whether arrow navigation wraps around the ends. */
 	loop: boolean;
 	/** Whether typeahead is enabled. */
@@ -78,6 +91,10 @@ export type MenuContext = {
 	setTriggerRef: (el: HTMLElement | null) => void;
 	/** Set the content ref (used by Content). */
 	setContentRef: (el: HTMLElement | null) => void;
+	/** Anchors the content to a viewport point, or back to the trigger with `null`. */
+	setAnchorPoint: (point: MenuAnchorPoint | null) => void;
+	/** Declares this menu a context menu (used by ContextTrigger on mount/unmount). */
+	setContextMenu: (value: boolean) => void;
 
 	/** Toggle the menu open state. */
 	toggle: (reason?: MenuOpenReason, event?: Event) => void;

--- a/packages/ui/src/lib/menu/root/menu-state.svelte.ts
+++ b/packages/ui/src/lib/menu/root/menu-state.svelte.ts
@@ -7,6 +7,7 @@ import {
 	clearTriggerFocusState
 } from './focus-state';
 import type {
+	MenuAnchorPoint,
 	MenuCanonicalCloseReason,
 	MenuChangeReason,
 	MenuCloseReason,
@@ -54,6 +55,8 @@ export type MenuState = {
 export function createMenuState(options: CreateMenuStateOptions): MenuState {
 	let closeReason: MenuCanonicalCloseReason = $state('none');
 	let contentRef: HTMLElement | null = $state(null);
+	let anchorPoint: MenuAnchorPoint | null = $state(null);
+	let isContextMenu = $state(false);
 	let cleanupTriggerBlurListener: (() => void) | undefined;
 	let pendingTriggerCloseFocusFrame: number | undefined;
 
@@ -175,6 +178,9 @@ export function createMenuState(options: CreateMenuStateOptions): MenuState {
 		// cancelled by the consumer must leave the menu's interaction state untouched.
 		keyboardNav.setCurrentId(null);
 		submenuIntent.cancel();
+		// Drop the pointer point too, so the next open doesn't reuse a stale cursor
+		// position — a keyboard reopen has to land on the trigger, not where the mouse was.
+		anchorPoint = null;
 		const triggerRef = options.getTriggerRef();
 		if (!triggerRef) return;
 		if (!TRIGGER_REFOCUS_REASONS.includes(reason)) return;
@@ -206,6 +212,14 @@ export function createMenuState(options: CreateMenuStateOptions): MenuState {
 
 	function setContentRef(el: HTMLElement | null) {
 		contentRef = el;
+	}
+
+	function setAnchorPoint(point: MenuAnchorPoint | null) {
+		anchorPoint = point;
+	}
+
+	function setContextMenu(value: boolean) {
+		isContextMenu = value;
 	}
 
 	let openFocusIntent: MenuOpenFocusIntent | null = null;
@@ -291,6 +305,12 @@ export function createMenuState(options: CreateMenuStateOptions): MenuState {
 		get contentRef() {
 			return contentRef;
 		},
+		get anchorPoint() {
+			return anchorPoint;
+		},
+		get isContextMenu() {
+			return isContextMenu;
+		},
 		get loop() {
 			return options.getLoop();
 		},
@@ -305,6 +325,8 @@ export function createMenuState(options: CreateMenuStateOptions): MenuState {
 		keyboardNav,
 		setTriggerRef,
 		setContentRef,
+		setAnchorPoint,
+		setContextMenu,
 		toggle,
 		open: openMenu,
 		close: closeMenu,

--- a/packages/ui/src/lib/primitives/floating.ts
+++ b/packages/ui/src/lib/primitives/floating.ts
@@ -6,8 +6,48 @@ import {
 	offset as offsetMiddleware,
 	size,
 	autoUpdate,
-	type Placement as FloatingPlacement
+	type Placement as FloatingPlacement,
+	type VirtualElement
 } from '@floating-ui/dom';
+
+/**
+ * What a floating panel can be positioned against: a real element, or a virtual
+ * one — an object that only knows how to report a rect. Floating UI supports
+ * both natively, in `computePosition` and in `autoUpdate` (which checks for a
+ * real element before observing it for resizes, and falls back to the virtual
+ * element's `contextElement` for the ancestor scroll listeners).
+ */
+export type FloatingAnchor = HTMLElement | VirtualElement | null;
+
+/**
+ * A zero-size anchor at a viewport point, for panels that follow the pointer
+ * instead of an element — a context menu at the cursor, a toolbar at a text
+ * selection.
+ *
+ * `contextElement` should be the surface the point was measured on: without it
+ * `autoUpdate` has no node whose scroll ancestors it can watch, so the panel
+ * would not track a scrolling container.
+ *
+ * Coordinates are viewport-relative (`clientX`/`clientY`) and positioning uses
+ * the `fixed` strategy, so the panel stays where the pointer was — which is what
+ * a native context menu does.
+ *
+ * Because the rect has no size, `--trigger-width` / `--trigger-height` resolve to
+ * `0px` on the panel. Everything else (`flip`, `shift`, `size`, the
+ * `--available-*` custom properties and `--transform-origin`) works unchanged,
+ * which is the whole reason to go through Floating UI rather than assigning
+ * `left`/`top` by hand.
+ */
+export function createPointAnchor(
+	x: number,
+	y: number,
+	contextElement?: Element | null
+): VirtualElement {
+	return {
+		getBoundingClientRect: () => new DOMRect(x, y, 0, 0),
+		...(contextElement ? { contextElement } : {})
+	};
+}
 
 /**
  * Placement options for floating elements.
@@ -150,7 +190,7 @@ function getTransformOrigin(placement: FloatingPlacement): string {
  * - `--available-height`: Available height between trigger and viewport edge
  * - `--transform-origin`: Coordinates for animations (e.g., "center top")
  */
-export function createFloating(anchorElement: HTMLElement | null, options: FloatingOptions = {}) {
+export function createFloating(anchorElement: FloatingAnchor, options: FloatingOptions = {}) {
 	// Thin wrapper over `floating` — the previous standalone implementation had
 	// drifted (it was missing `strategy: 'fixed'`, mispositioning portalled content).
 	return function action(floatingElement: HTMLElement) {
@@ -171,7 +211,7 @@ export function createFloating(anchorElement: HTMLElement | null, options: Float
  */
 export function floating(
 	floatingElement: HTMLElement,
-	options: { anchor: HTMLElement | null } & FloatingOptions
+	options: { anchor: FloatingAnchor } & FloatingOptions
 ) {
 	// Kept mutable so `updatePosition` always reads the CURRENT anchor/options.
 	// The previous version closed over the initial values: reactive changes to
@@ -266,7 +306,7 @@ export function floating(
 	start();
 
 	return {
-		update(newOptions: { anchor: HTMLElement | null } & FloatingOptions) {
+		update(newOptions: { anchor: FloatingAnchor } & FloatingOptions) {
 			const anchorChanged = newOptions.anchor !== currentOptions.anchor;
 			currentOptions = newOptions;
 

--- a/packages/ui/src/lib/primitives/index.ts
+++ b/packages/ui/src/lib/primitives/index.ts
@@ -7,4 +7,5 @@ export * from './scroll-lock.js';
 export * from './aria-hide-outside.js';
 export * from './click-outside.js';
 export * from './input-modality.js';
+export * from './long-press.js';
 export * from './swipe-gesture.js';

--- a/packages/ui/src/lib/primitives/long-press.test.ts
+++ b/packages/ui/src/lib/primitives/long-press.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect } from 'vitest';
+import {
+	hasMovedBeyond,
+	isLongPressPointer,
+	longPress,
+	LONG_PRESS_MOVE_TOLERANCE_PX,
+	type LongPressPoint
+} from './long-press';
+
+describe('hasMovedBeyond', () => {
+	const origin: LongPressPoint = { x: 100, y: 100 };
+
+	it('tolerates a finger that only trembles', () => {
+		expect(hasMovedBeyond(origin, { x: 104, y: 103 }, LONG_PRESS_MOVE_TOLERANCE_PX)).toBe(false);
+	});
+
+	it('measures the diagonal, not each axis on its own', () => {
+		// 8px on each axis is under the tolerance per axis but 11.3px away.
+		expect(hasMovedBeyond(origin, { x: 108, y: 108 }, LONG_PRESS_MOVE_TOLERANCE_PX)).toBe(true);
+	});
+
+	it('is exclusive at the tolerance itself', () => {
+		expect(hasMovedBeyond(origin, { x: 110, y: 100 }, LONG_PRESS_MOVE_TOLERANCE_PX)).toBe(false);
+	});
+});
+
+describe('isLongPressPointer', () => {
+	function event(init: PointerEventInit) {
+		return new PointerEvent('pointerdown', { isPrimary: true, button: 0, ...init });
+	}
+
+	it('accepts a primary touch or pen', () => {
+		expect(isLongPressPointer(event({ pointerType: 'touch' }))).toBe(true);
+		expect(isLongPressPointer(event({ pointerType: 'pen' }))).toBe(true);
+	});
+
+	it('ignores a mouse, which already has contextmenu', () => {
+		expect(isLongPressPointer(event({ pointerType: 'mouse' }))).toBe(false);
+	});
+
+	it('ignores secondary buttons and secondary contacts', () => {
+		expect(isLongPressPointer(event({ pointerType: 'touch', button: 2 }))).toBe(false);
+		expect(isLongPressPointer(event({ pointerType: 'touch', isPrimary: false }))).toBe(false);
+	});
+});
+
+describe('longPress action', () => {
+	const DELAY = 30;
+	const base = { bubbles: true, pointerId: 3, pointerType: 'touch', isPrimary: true, button: 0 };
+
+	function setup(options: { enabled?: boolean } = {}) {
+		const node = document.createElement('div');
+		document.body.append(node);
+
+		const fired: LongPressPoint[] = [];
+		const action = longPress(node, {
+			delay: DELAY,
+			onLongPress: (point) => fired.push(point),
+			...options
+		});
+
+		return {
+			node,
+			fired,
+			down: (x = 40, y = 60) =>
+				node.dispatchEvent(new PointerEvent('pointerdown', { ...base, clientX: x, clientY: y })),
+			move: (x: number, y: number) =>
+				window.dispatchEvent(new PointerEvent('pointermove', { ...base, clientX: x, clientY: y })),
+			up: () => window.dispatchEvent(new PointerEvent('pointerup', { ...base })),
+			cleanup: () => {
+				action.destroy();
+				node.remove();
+			}
+		};
+	}
+
+	/** Waits past the action's delay without depending on timer mocking. */
+	const held = () => new Promise((resolve) => setTimeout(resolve, DELAY * 2));
+
+	it('fires at the point the finger went down', async () => {
+		const t = setup();
+		t.down(40, 60);
+		await held();
+		expect(t.fired).toEqual([{ x: 40, y: 60 }]);
+		t.cleanup();
+	});
+
+	it('does not fire while the press is still short', async () => {
+		const t = setup();
+		t.down();
+		await new Promise((resolve) => setTimeout(resolve, DELAY / 3));
+		expect(t.fired).toHaveLength(0);
+		t.cleanup();
+	});
+
+	it('abandons the press once the finger travels — that is a scroll', async () => {
+		const t = setup();
+		t.down(40, 60);
+		t.move(40, 100);
+		await held();
+		expect(t.fired).toHaveLength(0);
+		t.cleanup();
+	});
+
+	it('keeps waiting through a tremble inside the tolerance', async () => {
+		const t = setup();
+		t.down(40, 60);
+		t.move(43, 62);
+		await held();
+		expect(t.fired).toHaveLength(1);
+		t.cleanup();
+	});
+
+	it('abandons the press when the finger lifts early', async () => {
+		const t = setup();
+		t.down();
+		t.up();
+		await held();
+		expect(t.fired).toHaveLength(0);
+		t.cleanup();
+	});
+
+	it('abandons the press when anything scrolls', async () => {
+		const t = setup();
+		t.down();
+		window.dispatchEvent(new Event('scroll'));
+		await held();
+		expect(t.fired).toHaveLength(0);
+		t.cleanup();
+	});
+
+	it('swallows the click the platform emits for the same gesture', async () => {
+		const t = setup();
+		let clicks = 0;
+		t.node.addEventListener('click', () => (clicks += 1));
+
+		t.down();
+		await held();
+		t.node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+		expect(t.fired).toHaveLength(1);
+		expect(clicks).toBe(0);
+		t.cleanup();
+	});
+
+	it('stops swallowing once the gesture is over', async () => {
+		const t = setup();
+		let clicks = 0;
+		t.node.addEventListener('click', () => (clicks += 1));
+
+		t.down();
+		await held();
+		// The first synthetic event consumes the suppression.
+		t.node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+		t.node.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true }));
+
+		expect(clicks).toBe(1);
+		t.cleanup();
+	});
+
+	it('does nothing while disabled', async () => {
+		const t = setup({ enabled: false });
+		t.down();
+		await held();
+		expect(t.fired).toHaveLength(0);
+		t.cleanup();
+	});
+
+	it('ignores a held mouse button', async () => {
+		const t = setup();
+		t.node.dispatchEvent(
+			new PointerEvent('pointerdown', { ...base, pointerType: 'mouse', clientX: 1, clientY: 1 })
+		);
+		await held();
+		expect(t.fired).toHaveLength(0);
+		t.cleanup();
+	});
+});

--- a/packages/ui/src/lib/primitives/long-press.ts
+++ b/packages/ui/src/lib/primitives/long-press.ts
@@ -1,0 +1,173 @@
+/**
+ * Long press on a touch or pen pointer, for surfaces that expose an alternative
+ * action the way a right click does on a mouse.
+ *
+ * It exists because touch has no `contextmenu` worth relying on: Android Chrome
+ * fires it, iOS Safari only does so for a few built-in element types, so a
+ * context menu that waits for that event is unreachable on a phone.
+ *
+ * Two details are what make it survive contact with a real device:
+ *
+ * 1. The press is abandoned as soon as the finger travels — a long press and the
+ *    start of a scroll look identical for the first few hundred milliseconds, and
+ *    the one thing worse than no menu is a menu that opens whenever the page is
+ *    slow to scroll. Nothing captures the pointer either: capturing it would take
+ *    the scroll away from the browser for the whole delay.
+ * 2. The `click` and `contextmenu` that the platform emits around the same
+ *    gesture are swallowed afterwards. Without that, the same finger press opens
+ *    the menu and then immediately dismisses it.
+ */
+
+export type LongPressPoint = { x: number; y: number };
+
+/** How long the pointer has to stay down. Matches the platform convention. */
+export const LONG_PRESS_DELAY_MS = 500;
+
+/** How far the pointer may drift before the press is treated as a drag/scroll. */
+export const LONG_PRESS_MOVE_TOLERANCE_PX = 10;
+
+/**
+ * How long the synthetic events that follow a long press are swallowed. Only has
+ * to outlive the platform's own emulation, which is immediate in practice; the
+ * timeout is there so a gesture that never produces them doesn't leave the
+ * listeners armed.
+ */
+const SUPPRESSION_WINDOW_MS = 700;
+
+/** Whether the pointer moved far enough from where it went down to abandon the press. */
+export function hasMovedBeyond(
+	start: LongPressPoint,
+	current: LongPressPoint,
+	tolerance: number
+): boolean {
+	return Math.hypot(current.x - start.x, current.y - start.y) > tolerance;
+}
+
+/**
+ * Whether this pointer should be considered for a long press at all.
+ *
+ * A mouse is excluded on purpose: it already has `contextmenu`, and treating a
+ * held left button as a long press would fire on every slow drag.
+ */
+export function isLongPressPointer(event: PointerEvent): boolean {
+	return event.isPrimary && event.button === 0 && event.pointerType !== 'mouse';
+}
+
+export type LongPressOptions = {
+	/** Whether the action listens at all. */
+	enabled?: boolean;
+	/** How long the pointer must stay down. Defaults to `LONG_PRESS_DELAY_MS`. */
+	delay?: number;
+	/** Movement tolerance in px. Defaults to `LONG_PRESS_MOVE_TOLERANCE_PX`. */
+	tolerance?: number;
+	/** Called once the press is held long enough, with the viewport point of the pointer. */
+	onLongPress: (point: LongPressPoint, event: PointerEvent) => void;
+};
+
+/**
+ * Svelte action: calls `onLongPress` when a touch or pen pointer is held on the
+ * node without travelling.
+ *
+ * @example
+ * ```svelte
+ * <div use:longPress={{ onLongPress: (point) => openAt(point) }}>…</div>
+ * ```
+ */
+export function longPress(node: HTMLElement, options: LongPressOptions) {
+	let currentOptions = options;
+	let timer: ReturnType<typeof setTimeout> | null = null;
+	let start: LongPressPoint | null = null;
+	let pointerId: number | null = null;
+	let releaseSuppression: (() => void) | null = null;
+
+	function isEnabled() {
+		return currentOptions.enabled ?? true;
+	}
+
+	function clearTimer() {
+		if (timer === null) return;
+		clearTimeout(timer);
+		timer = null;
+	}
+
+	function stopTracking() {
+		clearTimer();
+		start = null;
+		pointerId = null;
+		window.removeEventListener('pointermove', handlePointerMove);
+		window.removeEventListener('pointerup', stopTracking);
+		window.removeEventListener('pointercancel', stopTracking);
+		// Capture, so a scroll inside any container — not just the page — abandons the press.
+		window.removeEventListener('scroll', stopTracking, true);
+	}
+
+	/**
+	 * Swallows the `click` / `contextmenu` the platform emits for the same gesture.
+	 * Registered in the capture phase so they never reach the node's own handlers.
+	 */
+	function suppressFollowingEvents() {
+		releaseSuppression?.();
+
+		const suppress = (event: Event) => {
+			event.preventDefault();
+			event.stopPropagation();
+			release();
+		};
+
+		function release() {
+			clearTimeout(expiry);
+			releaseSuppression = null;
+			window.removeEventListener('click', suppress, true);
+			window.removeEventListener('contextmenu', suppress, true);
+		}
+
+		window.addEventListener('click', suppress, true);
+		window.addEventListener('contextmenu', suppress, true);
+		const expiry = setTimeout(release, SUPPRESSION_WINDOW_MS);
+		// Held so `destroy` can drop it: these listeners are on the window, and a
+		// surface that goes away mid-gesture must not keep swallowing the page's events.
+		releaseSuppression = release;
+	}
+
+	function handlePointerMove(event: PointerEvent) {
+		if (start === null || event.pointerId !== pointerId) return;
+		const tolerance = currentOptions.tolerance ?? LONG_PRESS_MOVE_TOLERANCE_PX;
+		if (hasMovedBeyond(start, { x: event.clientX, y: event.clientY }, tolerance)) {
+			stopTracking();
+		}
+	}
+
+	function handlePointerDown(event: PointerEvent) {
+		if (!isEnabled() || !isLongPressPointer(event)) return;
+		stopTracking();
+		start = { x: event.clientX, y: event.clientY };
+		pointerId = event.pointerId;
+
+		window.addEventListener('pointermove', handlePointerMove);
+		window.addEventListener('pointerup', stopTracking);
+		window.addEventListener('pointercancel', stopTracking);
+		window.addEventListener('scroll', stopTracking, true);
+
+		timer = setTimeout(() => {
+			const point = start;
+			stopTracking();
+			if (point === null) return;
+			suppressFollowingEvents();
+			currentOptions.onLongPress(point, event);
+		}, currentOptions.delay ?? LONG_PRESS_DELAY_MS);
+	}
+
+	node.addEventListener('pointerdown', handlePointerDown);
+
+	return {
+		update(newOptions: LongPressOptions) {
+			currentOptions = newOptions;
+			if (!isEnabled()) stopTracking();
+		},
+		destroy() {
+			stopTracking();
+			releaseSuppression?.();
+			node.removeEventListener('pointerdown', handlePointerDown);
+		}
+	};
+}


### PR DESCRIPTION
Click derecho sobre una superficie para abrir el menú, más long-press en touch y `Shift+F10` por teclado.

React Aria lo trata como una extensión de `Menu` y en el fondo tiene razón: debajo del trigger no cambia nada — `Content`, `Item`, `Group`, `Separator`, `Submenu`, `Overlay`, el keyboard nav, el typeahead y el layer stack son idénticos. Un componente `ContextMenu` aparte (lo que hace Radix) duplicaría todo eso para ganar un nombre.

Lo que no se copia es el mecanismo. Su `trigger="contextMenu"` sobre el mismo trigger no aplica acá: `Menu.Trigger` renderiza un `<button>` con `aria-haspopup`/`aria-expanded`, y una superficie de context menu no puede serlo — envuelve contenido arbitrario, a veces interactivo. Va como parte nueva.

```svelte
<Menu.Root>
	<Menu.ContextTrigger>Click derecho acá</Menu.ContextTrigger>
	<Menu.Content>
		<Menu.Item onAction={edit}>Edit</Menu.Item>
	</Menu.Content>
</Menu.Root>
```

## Cómo abre y dónde ancla

- **Click derecho** — en el puntero, pegado a él (`Menu.Content` baja su `offset` por defecto a `0` cuando es context menu). Volver a hacer click derecho re-ancla el menú abierto en vez de cerrarlo y reabrirlo.
- **Long press** en touch o pen — en el dedo. Sin esto el menú es inalcanzable en un teléfono: iOS Safari no dispara `contextmenu` de forma confiable sobre elementos arbitrarios.
- **`Shift+F10` o la tecla `ContextMenu`** — anclado a la superficie, con el primer ítem enfocado. No hay puntero, así que reusar la última posición del cursor pondría el panel donde el usuario de teclado nunca apuntó.

Un click izquierdo en cualquier lado cierra, **incluida la propia superficie**: `Menu.Content` le pasa `ignore: [triggerRef]` a `clickOutside`, que es correcto para un botón que togglea pero no para una superficie.

## Dos primitivas nuevas, reutilizables

- **`createPointAnchor(x, y, contextElement)`** — anclar un flotante a un punto del viewport en vez de a un elemento. Floating UI ya soporta *virtual elements* en `computePosition` y en `autoUpdate`, así que esto ensancha un tipo en vez de reimplementar posicionamiento: `flip`, `shift`, `size`, `--available-*` y `--transform-origin` siguen funcionando. (Posicionar a mano con `left/top` habría perdido todo eso.)
- **`longPress`** — acción con pointer events. Abandona el gesto apenas el dedo viaja, así un scroll lento nunca abre un menú, y no captura el puntero (robaría el scroll durante medio segundo). Suprime el `click` y el `contextmenu` que la plataforma emite por el mismo gesto, que si no abren el menú y lo cierran en el acto.

## Accesibilidad

La superficie es tab stop por defecto (`tabindex={0}`); `tabindex={-1}` para cuando vive dentro de un composite con roving tabindex.

Lleva `aria-keyshortcuts="Shift+F10"` y nada más: `aria-haspopup` y `aria-expanded` **no** son propiedades globales de ARIA, y en un elemento genérico serían inválidas. Eso es un límite real, no un olvido, y la documentación dice lo que se deriva de él: **un context menu nunca puede ser el único camino a una acción.**

## Verificación

`pnpm test` 1669/1669 en Chromium real (16 nuevos para la parte, 16 para la primitiva), `test:ssr` 23/23 (2 nuevos), `typecheck` limpio en lib y docs, `lint` limpio, y el build de docs y de la librería pasan.

Aparte: `pnpm docs:api` genera drift en `docs/src/content/table/api.json` — el `api.json` de Table tiene descripciones curadas a mano que la regeneración pisa, y le falta `data-keyboard-navigation`. Lo revertí para no mezclarlo acá.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XtKPSiZrfATzgLT3xD96Mq
