### PR TITLE
docs: rewrite the GitHub README as a front page

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,20 @@ publishes to npm automatically once merged to `main`.
 - Keep components accessible (keyboard navigation, ARIA, focus management).
 - Formatting is handled by Prettier; do not hand-format.
 
+## TODO files
+
+Every `*TODO.md` in the repo uses one checklist format, validated by
+`pnpm run todo:check` (which `pnpm run lint` also runs, so a malformed line
+fails CI).
+
+Each item carries, in order: status (`[ ]` / `[x]`), MoSCoW priority
+(`[M]` / `[S]` / `[C]` / `[W]`), execution priority (`[P0]`–`[P3]`), area,
+owner, target, and a short English description:
+
+```markdown
+- [ ] [M][P0][Area: Accessibility][Owner: @username][Target: 2026-04-30] Ensure keyboard trap works in nested dialogs.
+```
+
 ## Reporting bugs and requesting features
 
 Open an issue using the provided templates. For security issues, follow

--- a/README.md
+++ b/README.md
@@ -1,194 +1,123 @@
 # @human-kit/ui
 
-Monorepo for accessible, reusable UI components for Svelte 5.
-This repository contains the publishable library and the docs/demo app.
+[![npm](https://img.shields.io/npm/v/%40human-kit%2Fui?color=%230b7285)](https://www.npmjs.com/package/@human-kit/ui)
+[![CI](https://github.com/human-kit/ui/actions/workflows/ci.yml/badge.svg)](https://github.com/human-kit/ui/actions/workflows/ci.yml)
+[![license](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
 
-**[Documentation → ui.human-kit.com](https://ui.human-kit.com)**
+Headless, accessible UI components for **Svelte 5**. They ship the behavior —
+semantics, keyboard, focus management, positioning — and leave every pixel to you.
 
-## Quick Overview
+**[Documentation and live demos → ui.human-kit.com](https://ui.human-kit.com)**
 
-- npm library: `@human-kit/ui` (in `packages/ui`).
-- Docs/demo app: `docs` (SvelteKit + Vite).
-- Versioning and releases: `.changeset`.
-- PR automation: `scripts/pr.sh`.
+> **Status: beta.** Published as `1.0.0-beta.x`. The public API is close to
+> settled, but it can still change before `1.0.0`.
 
-## Project Structure
+## Why
 
-```text
-.
-|- packages/
-|  |- ui/              # publishable package @human-kit/ui
-|- docs/               # documentation site and playground
-|- .changeset/         # semantic versioning and release notes
-|- scripts/            # utility scripts (e.g. PR workflow)
-|- package.json        # monorepo orchestration
-|- pnpm-workspace.yaml # pnpm workspace definition
-|- pnpm-lock.yaml      # pnpm lockfile
-```
+- **Headless, not unstyled-by-accident.** Components expose their state as
+  `data-*` attributes (`data-state`, `data-disabled`, `data-focus-visible`, …)
+  and take a `class`. No theme to override, no CSS to reset.
+- **Svelte 5 native.** Runes throughout, `bind:` on every stateful prop, and an
+  opt-in `controlled*` escape hatch when you want to own the state.
+- **Accessibility is the product.** Focus trapping, focus restore by input
+  modality, `aria-*` wiring, typeahead, roving tabindex — tested against a
+  written contract, not by hand.
+- **One runtime dependency.** `@floating-ui/dom`, and only where things float.
+- **Ships as ESM with subpath exports**, so a bundler pulls in the one component
+  you imported.
 
-## Components Exported by the Library
-
-- `Calendar`
-- `ComboBox`
-- `Dialog`
-- `Input`
-- `Label`
-- `ListBox`
-- `LocaleProvider`
-- `Popover`
-- `Portal`
-- `Tree`
-- `primitives` and utilities (`cn`)
-
-## Package Installation (Consumers)
+## Install
 
 ```bash
-npm install @human-kit/ui
+pnpm add @human-kit/ui   # npm install / yarn add also fine
 ```
 
-Quick usage:
+Svelte `^5` is a peer dependency.
+
+## First component
+
+Every primitive is a namespace of composable parts:
 
 ```svelte
 <script lang="ts">
-	import { ComboBox, Dialog, Input, Label } from '@human-kit/ui';
+	import { Button } from '@human-kit/ui';
+	// leanest bundle: import { Button } from '@human-kit/ui/button';
+
+	let count = $state(0);
 </script>
+
+<Button.Root class="rounded-md bg-black px-3 py-1.5 text-white" onclick={() => count++}>
+	Clicked {count} times
+</Button.Root>
 ```
 
-## Local Development
+That is a real `<button>` with correct semantics, focus behavior and
+modality-aware focus attributes — and nothing you did not ask for.
 
-Recommended requirements:
+## Components
 
-- pnpm 9+
-- Node.js 20+
+| Category  | Components                                                                                                       |
+| --------- | ---------------------------------------------------------------------------------------------------------------- |
+| Form      | `Button`, `Checkbox`, `Input`, `TextArea`, `Label`, `NumberField`, `Switch`, `Toggle`, `ToggleGroup`, `Dropzone` |
+| Pickers   | `Autocomplete`, `ComboBox`, `ListBox`, `Calendar`, `Clock`, `DatePicker`, `DateRangePicker`, `TimePicker`        |
+| Overlays  | `Dialog`, `Drawer`, `Menu`, `Popover`, `Portal`                                                                  |
+| Structure | `Accordion`, `Collapsible`, `Table`, `Tabs`, `Tree`, `OverflowRow`                                               |
+| Utilities | `LocaleProvider`, `primitives`, and the `cn` class helper                                                        |
 
-Install and basic commands:
+Each one is also a subpath export — `@human-kit/ui/menu`, `@human-kit/ui/table`,
+and so on. Full API reference, anatomy and live demos live in
+[the docs](https://ui.human-kit.com).
+
+## Repository layout
+
+```text
+packages/ui/     the published library (@human-kit/ui)
+docs/            documentation site and playground (SvelteKit)
+.changeset/      versioning and release notes
+scripts/         repo automation (PR flow, changeset helpers, benchmarks)
+```
+
+pnpm workspace; `packages/*` and `docs` are the members.
+
+## Development
+
+Requires Node.js 20+ and pnpm 9+ (the exact version is pinned via
+`packageManager`, so `corepack enable` is enough).
 
 ```bash
 pnpm install
-pnpm run dev
+pnpm run dev         # docs site + playground
 ```
 
-## Root `package.json` Explained
+| Command              | What it runs                                                |
+| -------------------- | ----------------------------------------------------------- |
+| `pnpm run test`      | The library suite, in a real Chromium (Vitest browser mode) |
+| `pnpm run typecheck` | `svelte-check` over the library and the docs                |
+| `pnpm run lint`      | Prettier, ESLint and the TODO-format check                  |
+| `pnpm run build`     | Packages the library (`svelte-package` + `publint`)         |
+| `pnpm run docs:api`  | Regenerates the API tables the docs render                  |
 
-### Main Fields
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for the branch/PR workflow, the
+changeset rules and the coding conventions.
 
-| Field            | What it does                                              |
-| ---------------- | --------------------------------------------------------- |
-| `name`           | Internal monorepo name (`@human-kit/monorepo`).           |
-| `private`        | Prevents accidentally publishing the root package to npm. |
-| `type`           | Uses ESM (`"module"`) for JS scripts/config.              |
-| `packageManager` | Pins the pnpm version used across the repo and CI.        |
+## Releases
 
-Workspaces are defined in `pnpm-workspace.yaml` (`packages/*` and `docs`).
+Versioning runs on [Changesets](https://github.com/changesets/changesets), in
+prerelease mode. Any change under `packages/ui/src/**` needs a changeset — CI
+fails without one.
 
-### Scripts (What Each One Does)
+Merging to `main` triggers `.github/workflows/release.yml`, which either pushes
+a `changeset-release/main` branch with the version bump (merge it to publish) or,
+when nothing is left to version, publishes to npm and pushes the tags. Changes
+that only touch `docs/` never version anything; they just redeploy the site.
 
-| Script        | What it does                                                   |
-| ------------- | -------------------------------------------------------------- |
-| `dev`         | Starts the `docs` development environment using a pnpm filter. |
-| `build`       | Packages the `@human-kit/ui` library.                          |
-| `build:docs`  | Builds the `docs` site for production.                         |
-| `test`        | Runs library tests (`packages/ui`).                            |
-| `typecheck`   | Runs type checking for library and docs.                       |
-| `check`       | Runs `check` in all workspaces (`pnpm -r`).                    |
-| `format`      | Formats the whole repo with Prettier.                          |
-| `lint:md`     | Runs Markdown lint with `markdownlint-cli2`.                   |
-| `lint:md:fix` | Attempts to auto-fix Markdown issues.                          |
-| `todo:check`  | Validates required TODO checklist metadata format.             |
-| `lint`        | Validates formatting, ESLint, and TODO metadata format.        |
-| `release`     | Builds and publishes with Changesets (`changeset publish`).    |
-| `pr`          | Runs `scripts/pr.sh` for automated PR workflow.                |
+## Community
 
-### Root Dev Dependencies (Purpose)
+- [Contributing guide](./CONTRIBUTING.md)
+- [Code of conduct](./CODE_OF_CONDUCT.md)
+- [Security policy](./SECURITY.md) — please do not open public issues for vulnerabilities
+- [Table performance benchmarks](./BENCHMARKS.md)
 
-| Package                        | Purpose                                                   |
-| ------------------------------ | --------------------------------------------------------- |
-| `@changesets/changelog-github` | Generates GitHub-integrated changelogs in releases.       |
-| `@changesets/cli`              | Handles versioning and publishing for monorepo packages.  |
-| `@eslint/compat`               | Compatibility helpers for modern ESLint config migration. |
-| `@eslint/js`                   | Official base ESLint rules for JavaScript.                |
-| `eslint`                       | Primary linter for the repository.                        |
-| `eslint-config-prettier`       | Disables ESLint rules that conflict with Prettier.        |
-| `eslint-plugin-svelte`         | ESLint rules for Svelte files.                            |
-| `globals`                      | Global variable definitions by environment.               |
-| `prettier`                     | Code formatter.                                           |
-| `prettier-plugin-svelte`       | Prettier support for `.svelte` files.                     |
-| `prettier-plugin-tailwindcss`  | Automatically sorts Tailwind classes.                     |
-| `typescript`                   | TypeScript compiler and type system.                      |
-| `typescript-eslint`            | TypeScript parser and lint rules for ESLint.              |
+## License
 
-## Library `package.json` (`packages/ui`) Explained
-
-### Packaging and Quality Scripts
-
-| Script           | What it does                                      |
-| ---------------- | ------------------------------------------------- |
-| `package`        | `svelte-kit sync` + `svelte-package` + `publint`. |
-| `prepublishOnly` | Runs `package` before publishing to npm.          |
-| `prepare`        | Syncs SvelteKit types during install/prepare.     |
-| `check`          | Type-checks the library with `svelte-check`.      |
-| `test`           | Runs tests with Vitest.                           |
-
-### Runtime Dependencies
-
-- `@floating-ui/dom`: positioning for popovers/dialogs.
-- `class-variance-authority`: style variants driven by props.
-- `clsx`: conditional class composition.
-- `tailwind-merge`: smart Tailwind class merging.
-
-### Peer dependency
-
-- `svelte@^5.0.0`: the library expects Svelte 5 in consumer projects.
-
-## Release Workflow
-
-1. Work on a feature branch and run `pnpm run pr`.
-   - The script formats, validates, creates/updates changeset, commits, pushes, and opens/updates the PR.
-2. CI validates lint/typecheck/tests/build and enforces changeset presence for `packages/ui/src/**` changes.
-3. Merge the PR into `main`.
-4. Release is automated by GitHub Actions (`.github/workflows/release.yml`) using Changesets:
-   - It opens/updates a version PR (`chore: version packages`) or
-   - publishes to npm when version changes are ready.
-
-### Optional: AI-assisted changeset generation (confirm-first)
-
-- Add label `changeset:auto` to a PR to enable automatic changeset generation in CI.
-- Workflow: `.github/workflows/changeset-autogen.yml`.
-- The automation only writes a changeset when missing; maintainers still review/confirm bump type and notes in PR.
-- Provider order: `GEMINI_API_KEY` (preferred) -> `OPENAI_API_KEY` (fallback) -> deterministic non-AI summary.
-- Local helpers:
-  - `pnpm run changeset:auto:draft` (preview generated markdown)
-  - `pnpm run changeset:auto:apply` (write generated file if missing)
-
-## TODO Standard
-
-All repository TODO files (`*TODO.md`) must use one consistent, English checklist format.
-
-Required fields per checkbox item:
-
-- `Status`: `[ ]` (pending) or `[x]` (done)
-- `MoSCoW priority`: `[M]`, `[S]`, `[C]`, `[W]`
-- `Execution priority`: `[P0]`, `[P1]`, `[P2]`, `[P3]`
-- `Area/component`: `[Area: ...]`
-- `Owner`: `[Owner: ...]`
-- `Target date/milestone`: `[Target: ...]`
-- `Description`: short English sentence
-
-Canonical line template:
-
-`- [ ] [M][P0][Area: Accessibility][Owner: @username][Target: 2026-04-30] Ensure keyboard trap works in nested dialogs.`
-
-Validation:
-
-- Run `pnpm run todo:check` to validate TODO formatting.
-- `pnpm run lint` includes TODO validation and will fail on format violations.
-
-## Tech Stack
-
-- Svelte 5
-- SvelteKit
-- Vite 7
-- TypeScript
-- TailwindCSS 4
-- Vitest
-- Changesets
+[MIT](./LICENSE) © Agustin Delgado

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -45,7 +45,7 @@ Or import a single component via its subpath for the leanest bundle:
 
 | Category    | Components                                                                    |
 | ----------- | ----------------------------------------------------------------------------- |
-| Overlays    | `Dialog`, `Popover`, `Menu`, `Portal`                                         |
+| Overlays    | `Dialog`, `Drawer`, `Popover`, `Menu`, `Portal`                               |
 | Forms       | `Input`, `TextArea`, `Label`, `Checkbox`, `Switch`, `NumberField`, `Dropzone` |
 | Selection   | `ComboBox`, `Autocomplete`, `ListBox`, `Toggle`, `ToggleGroup`                |
 | Date & time | `Calendar`, `Clock`, `DatePicker`, `DateRangePicker`, `TimePicker`            |
@@ -58,11 +58,20 @@ Each component is also available as a subpath export (for example
 
 ## Styling
 
-Components ship class-based styles composed with
-[`tailwind-variants`](https://www.tailwind-variants.org/) and merged with
-[`tailwind-merge`](https://github.com/dcastil/tailwind-merge). A Tailwind CSS
-setup in the consuming app is expected for the default look, and every component
-accepts a `class` prop so you can override or extend styles.
+Components are headless: they ship no CSS and assume no framework. Each part
+takes a `class` and exposes its state as `data-*` attributes — `data-state`,
+`data-disabled`, `data-focus-visible`, `data-pressed` and so on — so you can
+style it with plain CSS, Tailwind, or anything else. Every component page in the
+docs lists its full data-attribute contract.
+
+```svelte
+<Button.Root class="rounded-md bg-black px-3 py-1.5 text-white data-[pressed]:opacity-80">
+	Save
+</Button.Root>
+```
+
+The only runtime dependency is [`@floating-ui/dom`](https://floating-ui.com), and
+only the components that position something against an anchor use it.
 
 ## Requirements
 


### PR DESCRIPTION
The GitHub README had drifted into a mirror of `package.json` — tables of dev dependencies and root fields — while getting the actual library wrong:

- the component list was about ten entries out of date (missing Drawer, Menu, Table, Tabs, NumberField, TextArea, Toggle, ToggleGroup, Clock, DatePicker, DateRangePicker, TimePicker, Accordion, Collapsible, Autocomplete, Dropzone, OverflowRow, Button, Checkbox, Switch);
- the "runtime dependencies" it listed (`class-variance-authority`, `clsx`, `tailwind-merge`) no longer exist: the only one left is `@floating-ui/dom`;
- the release flow it described was not the current one — today the workflow pushes `changeset-release/main` and links the compare URL rather than opening the pull request itself.

What is left is a front page: what the library is, its beta status, install, a first component, a real component table, the repository layout, the development commands, how a release works, and links to CONTRIBUTING / CODE_OF_CONDUCT / SECURITY / BENCHMARKS. Badges for npm, CI and the licence.

**It also corrects the package README** (`packages/ui/README.md`), which claimed the components ship styles built with `tailwind-variants` and that "a Tailwind CSS setup in the consuming app is expected for the default look". The library ships no CSS at all — its only dependency is `@floating-ui/dom` — so that section now describes the headless `data-*` contract instead. `Drawer` was missing from its table too.

The `*TODO.md` checklist format (the one `pnpm run todo:check` validates) moves to CONTRIBUTING, where the rest of the contributor rules already live.

Markdown only: it does not touch `packages/ui/src/**`, so it needs no changeset and versions nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
