### PR TITLE
fix(popover): let a non-modal popover scroll when it opens inside a modal

### DIFF
--- a/.changeset/lazy-popovers-scroll.md
+++ b/.changeset/lazy-popovers-scroll.md
@@ -1,0 +1,7 @@
+---
+'@human-kit/ui': patch
+---
+
+Fix non-modal popovers refusing to scroll when opened from inside a modal. A `ComboBox` listbox, a `Select` menu or any `Popover.Content` with `modal={false}` is portalled to the body, so it sits outside the dialog that holds the scroll lock — and that lock cancels wheel and touch events everywhere but its own node. The list rendered with a scrollbar that would not move.
+
+Non-modal popover content now registers itself as a live scroll region for as long as it is open, through a new `allowScrollWithin` action. It never takes the lock, so it cannot keep the page frozen on its own.

--- a/packages/ui/src/lib/popover/content/popover-content.svelte
+++ b/packages/ui/src/lib/popover/content/popover-content.svelte
@@ -5,7 +5,7 @@
 	import { browser } from '../../internal/environment';
 	import { floating, type ExtendedPlacement } from '../../primitives/floating';
 	import { focusTrap, type FocusTrapOptions } from '../../primitives/focus-trap';
-	import { scrollLock } from '../../primitives/scroll-lock';
+	import { allowScrollWithin, scrollLock } from '../../primitives/scroll-lock';
 	import { clickOutside } from '../../primitives/click-outside';
 	import { ariaHideOutside } from '../../primitives/aria-hide-outside';
 	import { releaseFocusedDescendant } from '../../primitives/release-focused-descendant';
@@ -350,6 +350,7 @@
 			}}
 			use:focusTrap={{ enabled: isOpen && isModal, restoreFocus: false, initialFocus }}
 			use:scrollLock={(isOpen || presence.isExiting) && isModal}
+			use:allowScrollWithin={isOpen && !isModal}
 			use:ariaHideOutside={isOpen && isModal}
 			style="position: fixed; z-index: {zIndex};"
 			{...restProps}

--- a/packages/ui/src/lib/primitives/scroll-lock.test.ts
+++ b/packages/ui/src/lib/primitives/scroll-lock.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, afterEach } from 'vitest';
-import { scrollLock } from './scroll-lock';
+import { allowScrollWithin, scrollLock } from './scroll-lock';
 
 function resetBodyStyles() {
 	document.body.style.overflow = '';
@@ -161,6 +161,49 @@ describe('scrollLock', () => {
 			} finally {
 				handle.destroy();
 				overlay.remove();
+			}
+		});
+
+		it('lets a registered non-modal overlay scroll while a modal holds the lock', () => {
+			// Un listbox de combobox se portalea fuera del diálogo: sin registrarlo, el
+			// bloqueo del diálogo le cancela la rueda y la lista no scrollea.
+			const modal = document.createElement('div');
+			document.body.appendChild(modal);
+			const { overlay, content } = scrollableOverlay();
+
+			const lock = scrollLock(modal, true);
+			const allowed = allowScrollWithin(overlay, true);
+
+			try {
+				const event = wheel(40);
+				content.dispatchEvent(event);
+				expect(event.defaultPrevented).toBe(false);
+			} finally {
+				allowed.destroy();
+				lock.destroy();
+				overlay.remove();
+				modal.remove();
+			}
+		});
+
+		it('stops allowing it once the non-modal overlay closes', () => {
+			const modal = document.createElement('div');
+			document.body.appendChild(modal);
+			const { overlay, content } = scrollableOverlay();
+
+			const lock = scrollLock(modal, true);
+			const allowed = allowScrollWithin(overlay, true);
+			allowed.update(false);
+
+			try {
+				const event = wheel(40);
+				content.dispatchEvent(event);
+				expect(event.defaultPrevented).toBe(true);
+			} finally {
+				allowed.destroy();
+				lock.destroy();
+				overlay.remove();
+				modal.remove();
 			}
 		});
 

--- a/packages/ui/src/lib/primitives/scroll-lock.ts
+++ b/packages/ui/src/lib/primitives/scroll-lock.ts
@@ -225,3 +225,45 @@ export function scrollLock(node: HTMLElement, enabled: boolean = true) {
 		}
 	};
 }
+
+/**
+ * Svelte action that keeps a node scrollable while *someone else* holds the lock, without
+ * locking anything itself.
+ *
+ * A non-modal overlay — a combobox listbox, a select menu — locks nothing, so it never
+ * registers as a live scroll region. That is fine on its own, and broken inside a modal:
+ * the dialog's lock cancels every wheel event outside its own node, and the listbox is
+ * portalled to the body rather than nested in the dialog. The list then renders with a
+ * scrollbar it refuses to move.
+ *
+ * Registering the node makes the existing "is this scroll inside an overlay?" check say
+ * yes for it too. The lock count is untouched, so this can never keep the page frozen.
+ *
+ * @example
+ * ```svelte
+ * <div use:allowScrollWithin={isOpen}>
+ *   Listbox portalled out of the dialog
+ * </div>
+ * ```
+ */
+export function allowScrollWithin(node: HTMLElement, enabled: boolean = true) {
+	const register = (on: boolean) => {
+		if (on) {
+			overlayNodes.add(node);
+		} else {
+			overlayNodes.delete(node);
+		}
+	};
+
+	register(enabled);
+
+	return {
+		update(newEnabled: boolean) {
+			register(newEnabled);
+			enabled = newEnabled;
+		},
+		destroy() {
+			register(false);
+		}
+	};
+}


### PR DESCRIPTION
Open a `ComboBox` inside a `Dialog` and its listbox renders with a scrollbar that will not move. Same for a `Select`, or any `Popover.Content` with `modal={false}`.

Two pieces that are each correct on their own disagree. The dialog freezes the page: it pins the body *and* cancels `wheel`/`touchmove` in the capture phase, because hiding body overflow does nothing when the real scroller is an inner pane. To stay usable it keeps a set of overlay nodes whose inner scrolling is still allowed — the ones that took the lock.

A non-modal popover takes no lock, deliberately: it does not trap focus, does not hide the rest from screen readers, and must not freeze anything. So it was never in that set. And because popover content is portalled to the body, it is not *inside* the dialog's node either. Every scroll it received was cancelled by an overlay that had no idea it existed.

## The fix

```ts
export function allowScrollWithin(node: HTMLElement, enabled = true) { … }
```

A second action that registers a node as a live scroll region **without touching the lock count**. That separation is the point: taking the lock is what freezes the page, so an action that only ever adds to the allow-set cannot leave the page stuck if it is misused or leaks — the worst case is one node that scrolls when nothing is locked, which is what would happen anyway.

`Popover.Content` uses it while it is open and non-modal, next to the `scrollLock` it already applies when it is modal. The two are mutually exclusive by construction.

## Tests

Two, in `scroll-lock.test.ts`, written against the situation rather than the implementation:

- a registered non-modal overlay scrolls its own content while a modal holds the lock
- it stops being allowed as soon as it closes, so a stale registration cannot punch a hole in the next lock

The existing behaviour is unchanged: the background still cannot scroll, and an overlay scroller pinned at its bound still refuses to chain out.