### PR TITLE
docs: give the Releases page the same prev/next chevrons

### DIFF
--- a/docs/src/lib/docs/components/doc-toolbar/doc-toolbar.svelte
+++ b/docs/src/lib/docs/components/doc-toolbar/doc-toolbar.svelte
@@ -14,7 +14,14 @@
 	const SOURCE_BRANCH = 'main';
 	const SOURCE_DIR = 'packages/ui/src/lib';
 
-	const slug = $derived(page.params.slug ?? '');
+	// `slug` defaults to the route param, which covers every markdown page. Pages
+	// with their own route (Releases) have no param, so they pass it explicitly —
+	// without it the prev/next lookup would miss and both chevrons would be dead.
+	// Those pages have neither a markdown source nor a component folder, so they
+	// also turn the menu off rather than link to two 404s.
+	let { slug: slugProp, menu = true }: { slug?: string; menu?: boolean } = $props();
+
+	const slug = $derived(slugProp ?? page.params.slug ?? '');
 
 	// Flatten the nav (in sidebar order) to find the pages either side of this one
 	// for the ↑ / ↓ buttons — the chevrons match the sidebar's vertical order.
@@ -87,19 +94,21 @@
 
 	<!-- Reusable docs Menu (styled parts + presence animation live in ./menu). A
 	     dropdown from a compact toolbar doesn't need the page scrim, so overlay off. -->
-	<Menu.Root>
-		<Menu.Trigger variant="outline" size="icon-sm" aria-label="Page options">
-			<Ellipsis />
-		</Menu.Trigger>
-		<Menu.Content placement="bottom-end" overlay={false}>
-			<Menu.Item onAction={openMarkdown}>
-				<Markdown />
-				View as Markdown
-			</Menu.Item>
-			<Menu.Item onAction={openSource}>
-				<Github />
-				View source
-			</Menu.Item>
-		</Menu.Content>
-	</Menu.Root>
+	{#if menu}
+		<Menu.Root>
+			<Menu.Trigger variant="outline" size="icon-sm" aria-label="Page options">
+				<Ellipsis />
+			</Menu.Trigger>
+			<Menu.Content placement="bottom-end" overlay={false}>
+				<Menu.Item onAction={openMarkdown}>
+					<Markdown />
+					View as Markdown
+				</Menu.Item>
+				<Menu.Item onAction={openSource}>
+					<Github />
+					View source
+				</Menu.Item>
+			</Menu.Content>
+		</Menu.Root>
+	{/if}
 </div>

--- a/docs/src/routes/docs/releases/+page.svelte
+++ b/docs/src/routes/docs/releases/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import releases from '$lib/docs/releases-data.json';
 	import { buttonVariants } from '$lib/docs/components/button/recipe';
+	import DocToolbar from '$lib/docs/components/doc-toolbar/doc-toolbar.svelte';
 	import { releaseAnchor } from '$lib/docs/releases.js';
 
 	interface Entry {
@@ -42,7 +43,12 @@
 	/>
 </svelte:head>
 
-<article class="mx-auto max-w-3xl">
+<article class="relative mx-auto max-w-3xl">
+	<!-- Same prev/next chevrons every markdown page gets. This route has no `slug`
+	     param, and no markdown or component source behind it, so it passes the slug
+	     by hand and drops the "View as Markdown / View source" menu. -->
+	<DocToolbar slug="releases" menu={false} />
+
 	<header class="hd-prose mb-10">
 		<h1>Releases</h1>
 		<p>


### PR DESCRIPTION
Releases was the only sidebar entry you could not walk past with the toolbar chevrons: it has its own route (`/docs/releases`) instead of a markdown page, so it never rendered `DocToolbar`.

Two things stood in the way of just dropping the component in:

- **The slug.** `DocToolbar` derived it from `page.params.slug`, which this route does not have. Without a slug the prev/next lookup misses and both chevrons render dead. It now takes an optional `slug` prop and the page passes `"releases"`.
- **The menu.** "View as Markdown" and "View source" both point at paths built from the slug — `/docs/releases.md` and `packages/ui/src/lib/releases` — and neither exists. A new `menu` prop leaves the menu out rather than shipping two 404s.

Every markdown page keeps the toolbar it already had; both props default to the previous behaviour.

**Verified:** `/docs/releases` renders `Previous: Accessibility` / `Next: About` and no page-options button, while `/docs/accessibility` still renders all three. Docs typecheck, lint, 28 tests and `docs build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
