### PR TITLE
feat(toggle-group): drop controlledValue, and stay quiet while unmounting

### DIFF
--- a/.changeset/toggle-group-owns-its-value.md
+++ b/.changeset/toggle-group-owns-its-value.md
@@ -1,0 +1,11 @@
+---
+'@human-kit/ui': major
+---
+
+**Breaking:** remove `ToggleGroup.Root`'s `controlledValue` prop, and stop the group from reporting a selection change while it is unmounting.
+
+- `value` is the source of truth whenever it is supplied, with `bind:value` or without — there is no longer a flag to declare which. `onChange` always fires on a real interaction, and the write-back still reaches a binding.
+- A parent that owns `value` and rejects a change still sees the group move; the supplied `value` takes the selection back on the parent's next render.
+- Unmounting the whole group no longer fires `onChange`. Previously the selected toggle unregistered during teardown, `disallowEmptySelection` picked a fallback, and the consumer heard a press the user never made — enough to navigate a URL-backed group straight back to the screen being left. Removing a single `Toggle.Root` from a group that stays mounted still falls back and reports.
+
+Migration: delete `controlledValue`. `value` + `onChange` without a binding already is the controlled case.

--- a/docs/src/content/toggle-group/api.json
+++ b/docs/src/content/toggle-group/api.json
@@ -10,7 +10,7 @@
 					"type": "ToggleGroupValue[]",
 					"required": false,
 					"default": null,
-					"description": "Selected values. Two-way by default — use `bind:value`."
+					"description": "Selected values, and the source of truth whenever it is supplied — with `bind:value`\nor without. Every change is written back here and reported through `onChange`; without\na binding that write only lands locally, so a parent that hears `onChange` and refuses\nthe change (never flowing a new `value` down) sees the group move anyway, and snap back\nto the supplied `value` the next time the parent renders."
 				},
 				{
 					"name": "defaultValue",
@@ -18,13 +18,6 @@
 					"required": false,
 					"default": null,
 					"description": "Initially selected values, for when `value` is not supplied."
-				},
-				{
-					"name": "controlledValue",
-					"type": "boolean",
-					"required": false,
-					"default": "false",
-					"description": "Opt into fully controlled state: the component stops writing back to `value` and\nonly reports through `onChange`, so the parent can reject a change by not flowing\nthe new value back down. Off by default, because `bind:value` — the common case —\nneeds the write-back to work at all."
 				},
 				{
 					"name": "onChange",

--- a/packages/ui/src/lib/toggle-group/README.md
+++ b/packages/ui/src/lib/toggle-group/README.md
@@ -19,6 +19,12 @@
 ## Usage guidelines
 
 - Use `value` / `defaultValue` arrays for both single and multiple selection.
+- Use `bind:value` to hand the group your state, or plain `value` + `onChange` to own it
+  yourself. There is no flag to declare which: supplying `value` makes it the source of
+  truth either way, and `onChange` always reports.
+- A parent that owns `value` and rejects a change — never flowing a new one down — still
+  sees the group move, and the group snaps back to the supplied `value` on the parent's
+  next render. Reject by rendering, not by staying silent.
 - Use `selectionMode="single"` when only one toggle can be selected.
 - Use `selectionMode="multiple"` when several toggles can be selected.
 - Use `disallowEmptySelection` when at least one enabled toggle must remain selected.
@@ -48,4 +54,8 @@
 ## Notes
 
 - Grouped toggles ignore their standalone `selected` and `defaultSelected` props.
+- Removing one `Toggle.Root` from a mounted group is a real selection change: with
+  `disallowEmptySelection` the group picks a fallback and fires `onChange`. Unmounting the
+  whole group is not, and reports nothing — otherwise leaving a screen would look like the
+  user pressing the last toggle on the way out.
 - Form serialization is out of scope for this primitive.

--- a/packages/ui/src/lib/toggle-group/TODO.md
+++ b/packages/ui/src/lib/toggle-group/TODO.md
@@ -9,3 +9,5 @@
 - [x] [M][P0][Area: Interaction][Owner: Unassigned][Target: Done] Scope group keyboard handling to registered toggle buttons only.
 - [x] [M][P0][Area: Interaction][Owner: Unassigned][Target: Done] Clear grouped focus state when the focused toggle becomes disabled.
 - [x] [M][P0][Area: Testing][Owner: Unassigned][Target: Done] Add regression coverage for mount reconciliation, controlled sync, duplicates, dynamic mode changes, nested controls, and disabled focused toggles.
+- [x] [M][P0][Area: State][Owner: Unassigned][Target: Done] Stop reporting a selection change while the group is being torn down.
+- [x] [M][P0][Area: API][Owner: Unassigned][Target: Done] Drop `controlledValue`: `value` is the source of truth whenever it is supplied, bound or not.

--- a/packages/ui/src/lib/toggle-group/root/context.svelte.test.ts
+++ b/packages/ui/src/lib/toggle-group/root/context.svelte.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { createToggleGroupContext, type ToggleGroupValue } from './context.svelte.js';
+
+function createGroup() {
+	const changes: ToggleGroupValue[][] = [];
+	const group = createToggleGroupContext({
+		initialValue: ['bold'],
+		disallowEmptySelection: true,
+		onValueChange: (value) => changes.push(value)
+	});
+
+	group.registerToggle('bold', {});
+	group.registerToggle('italic', {});
+
+	return { group, changes };
+}
+
+describe('createToggleGroupContext', () => {
+	it('reports a removed toggle only while the group is live', () => {
+		const { group, changes } = createGroup();
+
+		// Before the root marks itself live — which on the server never happens — an
+		// unregistration is the group being built or thrown away, not a selection changing.
+		group.unregisterToggle('bold');
+		expect(changes).toEqual([]);
+
+		group.registerToggle('bold', {});
+		group.setLive(true);
+		group.unregisterToggle('bold');
+
+		expect(changes).toEqual([['italic']]);
+		expect(group.isSelected('italic')).toBe(true);
+	});
+
+	it('goes quiet again once the group stops being live', () => {
+		const { group, changes } = createGroup();
+
+		group.setLive(true);
+		group.setLive(false);
+		group.unregisterToggle('bold');
+
+		expect(changes).toEqual([]);
+	});
+});

--- a/packages/ui/src/lib/toggle-group/root/context.svelte.ts
+++ b/packages/ui/src/lib/toggle-group/root/context.svelte.ts
@@ -15,7 +15,6 @@ type ToggleRegistration = {
 
 export type CreateToggleGroupContextOptions = {
 	initialValue?: ToggleGroupValue[];
-	isControlled?: boolean;
 	selectionMode?: ToggleGroupSelectionMode;
 	isDisabled?: boolean;
 	orientation?: ToggleGroupOrientation;
@@ -35,6 +34,7 @@ export type ToggleGroupContext = {
 		options: { isDisabled?: boolean; element?: HTMLButtonElement | null; owner?: symbol }
 	) => void;
 	unregisterToggle: (value: ToggleGroupValue) => void;
+	setLive: (live: boolean) => void;
 	setSelectionMode: (mode: ToggleGroupSelectionMode) => void;
 	setDisabled: (disabled: boolean) => void;
 	setOrientation: (orientation: ToggleGroupOrientation) => void;
@@ -109,7 +109,6 @@ export function valuesToArray(
 export function createToggleGroupContext(
 	options: CreateToggleGroupContextOptions
 ): ToggleGroupContext {
-	const isControlled = options.isControlled ?? false;
 	let selectionMode = $state(options.selectionMode ?? 'single');
 	let isDisabled = $state(options.isDisabled ?? false);
 	let orientation = $state(options.orientation ?? 'horizontal');
@@ -121,6 +120,10 @@ export function createToggleGroupContext(
 	);
 	let focusedValue = $state<ToggleGroupValue | null>(null);
 	let focusVisible = $state(false);
+	// Whether the group is mounted and interactive. Plain `let`, not `$state`: nothing renders
+	// from it, and the reads happen while toggles register and unregister, where a reactive
+	// read would only add a dependency.
+	let isLive = false;
 
 	const toggles = new SvelteMap<ToggleGroupValue, ToggleRegistration>();
 	const toggleOrder = $state<ToggleGroupValue[]>([]);
@@ -217,14 +220,6 @@ export function createToggleGroupContext(
 
 		if (!didChange) return false;
 
-		if (isControlled && changeOptions?.notify !== false) {
-			// Controlled mode: request the change and let the parent apply it via props.
-			// Mirrors Accordion's identical `setOpen`, which had this guard while this one
-			// silently fell through and applied the change the parent might have rejected.
-			options.onValueChange?.(nextValue);
-			return true;
-		}
-
 		selectedValues = normalizedValues;
 
 		if (changeOptions?.notify !== false) {
@@ -238,8 +233,6 @@ export function createToggleGroupContext(
 		changedValue?: ToggleGroupValue,
 		changeOptions?: { notify?: boolean }
 	) {
-		if (isControlled) return;
-
 		const nextValues = new SvelteSet(selectedValues);
 		let removedSelectedValue: ToggleGroupValue | undefined;
 
@@ -301,6 +294,14 @@ export function createToggleGroupContext(
 		reconcileSelection(value, { notify: isExisting });
 	}
 
+	// Turned on by the root as it renders and off as it goes away, which is the only way to
+	// tell the two unregistrations apart: a toggle removed from a live group leaves a group
+	// behind that still has to show something, while a group on its way out has no one left
+	// to show anything to.
+	function setLive(live: boolean) {
+		isLive = live;
+	}
+
 	function unregisterToggle(value: ToggleGroupValue) {
 		if (!toggles.has(value)) return;
 		toggles.delete(value);
@@ -314,13 +315,20 @@ export function createToggleGroupContext(
 			focusedValue = null;
 		}
 
+		// Only a live group can lose a toggle from under it. Outside that window the toggle is
+		// leaving because the group is — on the client while it unmounts, on the server as the
+		// markup closes — and picking a fallback would report a selection the user never made,
+		// to a consumer already on its way out. Bound to a URL, that fake change navigated
+		// straight back to the screen being left.
+		if (!isLive) return;
+
 		reconcileSelection(value);
 	}
 
 	function setSelectionMode(mode: ToggleGroupSelectionMode) {
 		if (selectionMode === mode) return;
 		selectionMode = mode;
-		setSelection(selectedValues, { notify: !isControlled });
+		setSelection(selectedValues);
 		reconcileSelection();
 	}
 
@@ -443,6 +451,7 @@ export function createToggleGroupContext(
 		},
 		registerToggle: asCommand(registerToggle),
 		unregisterToggle: asCommand(unregisterToggle),
+		setLive: asCommand(setLive),
 		setSelectionMode: asCommand(setSelectionMode),
 		setDisabled: asCommand(setDisabled),
 		setOrientation: asCommand(setOrientation),

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-rejecting-parent-test.svelte
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-rejecting-parent-test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+	import { Toggle } from '../../toggle/index.js';
+	import { ToggleGroup } from '../index';
+	import type { ToggleGroupValue } from '../root/context.svelte';
+
+	type Props = {
+		onChange?: (value: ToggleGroupValue[]) => void;
+	};
+
+	let { onChange }: Props = $props();
+
+	// A parent that owns the selection and refuses every change: it supplies `value` without
+	// `bind:`, listens to `onChange`, and never flows a new value down.
+	let owned = $state<ToggleGroupValue[]>(['bold']);
+</script>
+
+<ToggleGroup.Root value={owned} {onChange} aria-label="Text style">
+	<Toggle.Root value="bold" data-testid="toggle-bold">Bold</Toggle.Root>
+	<Toggle.Root value="italic" data-testid="toggle-italic">Italic</Toggle.Root>
+</ToggleGroup.Root>
+
+<!-- A new array with the same contents: the parent rendering again without changing its
+	mind, which is when the supplied `value` takes the selection back. -->
+<button type="button" data-rerender-parent onclick={() => (owned = [...owned])}>
+	Re-render parent
+</button>

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-root.svelte
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-root.svelte
@@ -18,7 +18,6 @@
 		id,
 		value = $bindable(),
 		defaultValue,
-		controlledValue = false,
 		onChange,
 		selectionMode = 'single',
 		disabled: disabledProp = false,
@@ -33,18 +32,12 @@
 		...restProps
 	}: ToggleGroupRootProps = $props();
 
-	// Controlled-ness is opt-in, not inferred from `value` being defined: `bind:value` and
-	// `value={...}` are indistinguishable at runtime. It used to be inferred here, and the
-	// write-back below ignored the result anyway, so a controlled parent could not reject
-	// a change — the selection moved regardless of what `onChange` decided.
-	const isControlled = untrack(() => controlledValue);
 	const instanceId = untrack(() => id) ?? generatedId;
 
 	let rootRef: HTMLDivElement | null = $state(null);
 
 	const toggleGroup = setToggleGroupContext(
 		createToggleGroupContext({
-			isControlled,
 			// `value` seeds the initial selection whenever it is supplied, bound or not.
 			initialValue: untrack(() => value) ?? untrack(() => defaultValue),
 			selectionMode: (() => selectionMode)(),
@@ -52,15 +45,28 @@
 			orientation: (() => orientation)(),
 			disallowEmptySelection: (() => disallowEmptySelection)(),
 			onValueChange: (nextValue) => {
-				if (!isControlled) {
-					value = nextValue;
-				}
+				// One path for both usages: with `bind:value` this reaches the parent, and
+				// without a binding the write stays local, so nothing here has to know
+				// which one the caller chose.
+				value = nextValue;
 				onChange?.(nextValue);
 			}
 		})
 	);
 
 	context = toggleGroup;
+
+	// Marks the window in which a toggle disappearing is a real change rather than the group
+	// itself coming or going. `$effect.pre` because Svelte destroys an effect's children
+	// before running that effect's own teardown, so an `onDestroy` here would fire *after*
+	// every toggle had already unregistered: this one is created while the script runs,
+	// before the children exist, so it is first in destroy order and its cleanup lands ahead
+	// of theirs. On the server it never runs, which is right too — there the toggles
+	// unregister as the markup closes and nobody is listening any more.
+	$effect.pre(() => {
+		toggleGroup.setLive(true);
+		return () => toggleGroup.setLive(false);
+	});
 
 	const disabled = $derived(toggleGroup.isDisabled);
 	const multiple = $derived(toggleGroup.selectionMode === 'multiple');
@@ -86,11 +92,10 @@
 		toggleGroup.setDisallowEmptySelection(disallowEmptySelection);
 	});
 
-	// Whether to adopt an incoming `value` is a separate question from who owns the state,
-	// so it is latched at init off the prop rather than off `controlledValue`: a parent
-	// that supplies `value` drives the selection, bound or not. Latched, not reactive —
-	// re-checking `value !== undefined` would switch this on the moment our own write-back
-	// defines it, and the component would then re-adopt the echo of its own change.
+	// A parent that supplies `value` drives the selection, bound or not. Latched at init,
+	// not reactive — re-checking `value !== undefined` would switch this on the moment our
+	// own write-back defines it, and a `defaultValue`-only group would start following the
+	// echo of its own changes.
 	const adoptsValueProp = untrack(() => value !== undefined);
 
 	$effect(() => {

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-ssr.test.ts
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-ssr.test.ts
@@ -32,6 +32,23 @@ describe('ToggleGroup SSR', () => {
 		expect(underline).toContain('aria-pressed="true"');
 	});
 
+	it('reports nothing while rendering', () => {
+		const changes: unknown[] = [];
+
+		render(ToggleGroupTest, {
+			props: {
+				value: ['bold'],
+				disallowEmptySelection: true,
+				onChange: (value) => changes.push(value)
+			}
+		});
+
+		// The toggles unregister as the markup closes, and a fallback picked there would reach
+		// a consumer whose HTML is already written — in SvelteKit, one whose `onChange`
+		// navigates, which fails the request outright.
+		expect(changes).toEqual([]);
+	});
+
 	it('renders empty default state before hydration', () => {
 		const { body } = render(ToggleGroupTest);
 		const bold = getTag(body, 'data-testid="toggle-bold"');

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-teardown-order-child.svelte
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-teardown-order-child.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+
+	type Props = {
+		/** Shared log, so the parent can assert who tore down first. */
+		record: (step: string) => void;
+	};
+
+	let { record }: Props = $props();
+
+	// Stands in for `Toggle.Root`, which unregisters from `onDestroy`.
+	onDestroy(() => record('child-destroy'));
+</script>

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-teardown-order-test.svelte
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-teardown-order-test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { onDestroy } from 'svelte';
+	import TeardownOrderChild from './toggle-group-teardown-order-child.svelte';
+
+	type Props = {
+		/** Shared log, so the test can assert who tore down first. */
+		record: (step: string) => void;
+	};
+
+	let { record }: Props = $props();
+
+	// The ordering `ToggleGroup.Root` depends on, isolated from the group so a regression in
+	// Svelte shows up here as a failing assumption rather than as a mystery in the group.
+	// `$effect.pre` is created while this script runs — before anything below it exists — so
+	// it is the first child effect and its cleanup runs first. `onDestroy` is this
+	// component's own teardown, which Svelte runs only after every child is gone.
+	$effect.pre(() => () => record('root-pre-cleanup'));
+	onDestroy(() => record('root-destroy'));
+</script>
+
+<TeardownOrderChild {record} />

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-test.svelte
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-test.svelte
@@ -10,12 +10,6 @@
 	type Props = {
 		value?: ToggleGroupValue[];
 		defaultValue?: ToggleGroupValue[];
-		/**
-		 * Opt into fully controlled state. Separate from merely passing `value`: the
-		 * harness always binds, and most tests here exercise that binding, while a couple
-		 * exercise a parent that owns the state and rejects changes.
-		 */
-		controlledValue?: boolean;
 		selectionMode?: ToggleGroupSelectionMode;
 		orientation?: ToggleGroupOrientation;
 		disabled?: boolean;
@@ -36,7 +30,6 @@
 	let {
 		value = $bindable(),
 		defaultValue,
-		controlledValue = false,
 		selectionMode = 'single',
 		orientation = 'horizontal',
 		disabled = false,
@@ -71,7 +64,6 @@
 
 <ToggleGroup.Root
 	bind:value
-	{controlledValue}
 	{defaultValue}
 	selectionMode={renderedSelectionMode}
 	{orientation}

--- a/packages/ui/src/lib/toggle-group/root/toggle-group-unmount-test.svelte
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group-unmount-test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+	import { Toggle } from '../../toggle/index.js';
+	import { ToggleGroup } from '../index';
+	import type { ToggleGroupValue } from '../root/context.svelte';
+
+	type Props = {
+		value?: ToggleGroupValue[];
+		onChange?: (value: ToggleGroupValue[]) => void;
+	};
+
+	let { value = $bindable(), onChange }: Props = $props();
+
+	let mounted = $state(true);
+	let showUnderline = $state(true);
+</script>
+
+<!-- The selected toggle is the last one, so a fallback picked behind the consumer's back
+	wraps around to the first and is impossible to mistake for the value it started with. -->
+{#if mounted}
+	<ToggleGroup.Root bind:value disallowEmptySelection {onChange} aria-label="Text style">
+		<Toggle.Root value="bold" data-testid="toggle-bold">Bold</Toggle.Root>
+		<Toggle.Root value="italic" data-testid="toggle-italic">Italic</Toggle.Root>
+		{#if showUnderline}
+			<Toggle.Root value="underline" data-testid="toggle-underline">Underline</Toggle.Root>
+		{/if}
+	</ToggleGroup.Root>
+{/if}
+
+<button type="button" data-unmount-group onclick={() => (mounted = false)}>Unmount group</button>
+<button type="button" data-remove-underline onclick={() => (showUnderline = false)}>
+	Remove underline
+</button>
+<output data-current-value>{JSON.stringify(value ?? [])}</output>

--- a/packages/ui/src/lib/toggle-group/root/toggle-group.test.ts
+++ b/packages/ui/src/lib/toggle-group/root/toggle-group.test.ts
@@ -4,7 +4,10 @@ import { render } from 'vitest-browser-svelte';
 import ToggleGroupDuplicateTest from './toggle-group-duplicate-test.svelte';
 import ToggleGroupNumericStringTest from './toggle-group-numeric-string-test.svelte';
 import ToggleGroupOrderTest from './toggle-group-order-test.svelte';
+import ToggleGroupRejectingParentTest from './toggle-group-rejecting-parent-test.svelte';
+import ToggleGroupTeardownOrderTest from './toggle-group-teardown-order-test.svelte';
 import ToggleGroupTest from './toggle-group-test.svelte';
+import ToggleGroupUnmountTest from './toggle-group-unmount-test.svelte';
 
 function getToggle(testId: string) {
 	const toggle = document.querySelector<HTMLButtonElement>(`[data-testid="${testId}"]`);
@@ -121,37 +124,25 @@ describe('ToggleGroup.Root', () => {
 		expect(changes).toEqual([]);
 	});
 
-	it('allows controlled empty value even with disallowEmptySelection', async () => {
+	it('honours disallowEmptySelection over an empty supplied value', async () => {
 		const changes: unknown[] = [];
 		render(ToggleGroupTest, {
 			value: [],
-			controlledValue: true,
 			disallowEmptySelection: true,
 			onChange: (value) => changes.push(value)
 		});
 		const bold = getToggle('toggle-bold');
 
-		// The parent owns an empty selection, and `disallowEmptySelection` must not
-		// override it by picking a fallback on the component's own initiative.
-		expect(bold.getAttribute('aria-pressed')).toBe('false');
-
-		await userEvent.click(bold);
-
-		// The press is reported, but this parent never flows it back down — so nothing
-		// moves. Previously the component suppressed the fallback (acting controlled) yet
-		// applied the click anyway (acting uncontrolled); that split is now gone, and
-		// "controlled" means the same thing on both paths.
-		expect(changes).toEqual([['bold']]);
-		expect(bold.getAttribute('aria-pressed')).toBe('false');
+		// Same resolution as `defaultValue: []`: an empty selection is not one of the states
+		// this group can be in, so it settles on the first toggle without announcing it.
+		expect(bold.getAttribute('aria-pressed')).toBe('true');
+		expect(changes).toEqual([]);
 	});
 
-	it('applies the press itself when an empty value is merely bound', async () => {
+	it('applies and reports a press when value is supplied', async () => {
 		const changes: unknown[] = [];
 		render(ToggleGroupTest, {
 			value: [],
-			// No `controlledValue`: an ordinary two-way binding, so the component owns the
-			// change and writes it back. This is the half of the old hybrid behaviour that
-			// consumers actually relied on.
 			onChange: (value) => changes.push(value)
 		});
 		const bold = getToggle('toggle-bold');
@@ -160,6 +151,28 @@ describe('ToggleGroup.Root', () => {
 
 		expect(bold.getAttribute('aria-pressed')).toBe('true');
 		expect(changes).toEqual([['bold']]);
+	});
+
+	it('takes the selection back when a parent that rejected a change renders again', async () => {
+		const changes: unknown[] = [];
+		render(ToggleGroupRejectingParentTest, { onChange: (value) => changes.push(value) });
+		const bold = getToggle('toggle-bold');
+		const italic = getToggle('toggle-italic');
+		const rerenderParent = document.querySelector<HTMLButtonElement>('[data-rerender-parent]');
+
+		await userEvent.click(italic);
+
+		// The press is reported and applied: without a binding the write-back stays local,
+		// so the group cannot know the parent disagreed.
+		expect(changes).toEqual([['italic']]);
+		expect(italic.getAttribute('aria-pressed')).toBe('true');
+
+		await userEvent.click(rerenderParent as HTMLButtonElement);
+
+		// The supplied `value` is the source of truth, so the parent's next render wins.
+		expect(bold.getAttribute('aria-pressed')).toBe('true');
+		expect(italic.getAttribute('aria-pressed')).toBe('false');
+		expect(changes).toEqual([['italic']]);
 	});
 
 	it('does not fire onChange for external controlled value updates', async () => {
@@ -210,13 +223,11 @@ describe('ToggleGroup.Root', () => {
 		expect(italic.getAttribute('aria-pressed')).toBe('true');
 	});
 
-	it('keeps a controlled selection when the selected toggle becomes disabled', async () => {
+	it('reports the fallback when a supplied selection becomes disabled', async () => {
 		const changes: unknown[] = [];
 		render(ToggleGroupTest, {
 			value: ['bold'],
-			// Parent-owned: disabling the selected toggle must not make the component
-			// publish a different selection by itself.
-			controlledValue: true,
+			disallowEmptySelection: true,
 			onChange: (value) => changes.push(value)
 		});
 		const bold = getToggle('toggle-bold');
@@ -224,23 +235,83 @@ describe('ToggleGroup.Root', () => {
 
 		await userEvent.click(disableBold as HTMLButtonElement);
 
+		// A disabled toggle cannot stay pressed, so the group moves — and says so, instead of
+		// leaving the parent's `value` quietly disagreeing with what is on screen.
 		expect(bold.hasAttribute('disabled')).toBe(true);
-		expect(bold.getAttribute('aria-pressed')).toBe('true');
-		expect(document.querySelector('[data-current-value]')?.textContent).toBe('["bold"]');
-		expect(changes).toEqual([]);
+		expect(bold.getAttribute('aria-pressed')).toBe('false');
+		expect(getToggle('toggle-italic').getAttribute('aria-pressed')).toBe('true');
+		expect(changes).toEqual([['italic']]);
 	});
 
 	it('falls back when a selected toggle is removed with disallowEmptySelection', async () => {
+		const changes: unknown[] = [];
 		render(ToggleGroupTest, {
 			defaultValue: ['bold'],
-			disallowEmptySelection: true
+			disallowEmptySelection: true,
+			onChange: (value) => changes.push(value)
 		});
 		const removeBold = document.querySelector<HTMLButtonElement>('[data-remove-bold]');
 
 		await userEvent.click(removeBold as HTMLButtonElement);
 
+		// The group stays mounted, so the selection really did move and the consumer has to
+		// hear about it — the opposite of the same toggle disappearing with the whole group.
 		expect(document.querySelector('[data-testid="toggle-bold"]')).toBeNull();
 		expect(getToggle('toggle-italic').getAttribute('aria-pressed')).toBe('true');
+		expect(changes).toEqual([['italic']]);
+	});
+
+	it('tears the root down before its toggles, which is what makes the two tellable apart', async () => {
+		const steps: string[] = [];
+		const screen = render(ToggleGroupTeardownOrderTest, { record: (step) => steps.push(step) });
+
+		await screen.unmount();
+
+		expect(steps).toEqual(['root-pre-cleanup', 'child-destroy', 'root-destroy']);
+	});
+
+	it('reports nothing when the whole group unmounts', async () => {
+		const changes: unknown[] = [];
+		const screen = render(ToggleGroupUnmountTest, {
+			value: ['underline'],
+			onChange: (value) => changes.push(value)
+		});
+
+		expect(getToggle('toggle-underline').getAttribute('aria-pressed')).toBe('true');
+
+		await screen.unmount();
+
+		expect(changes).toEqual([]);
+	});
+
+	it('reports nothing when the group is removed while the page stays', async () => {
+		const changes: unknown[] = [];
+		render(ToggleGroupUnmountTest, {
+			value: ['underline'],
+			onChange: (value) => changes.push(value)
+		});
+		const unmountGroup = document.querySelector<HTMLButtonElement>('[data-unmount-group]');
+
+		await userEvent.click(unmountGroup as HTMLButtonElement);
+
+		expect(document.querySelector('[data-testid="toggle-underline"]')).toBeNull();
+		expect(changes).toEqual([]);
+		expect(document.querySelector('[data-current-value]')?.textContent).toBe('["underline"]');
+	});
+
+	it('falls back and reports when one toggle is removed from a mounted group', async () => {
+		const changes: unknown[] = [];
+		render(ToggleGroupUnmountTest, {
+			value: ['underline'],
+			onChange: (value) => changes.push(value)
+		});
+		const removeUnderline = document.querySelector<HTMLButtonElement>('[data-remove-underline]');
+
+		await userEvent.click(removeUnderline as HTMLButtonElement);
+
+		expect(document.querySelector('[data-testid="toggle-underline"]')).toBeNull();
+		expect(getToggle('toggle-bold').getAttribute('aria-pressed')).toBe('true');
+		expect(changes).toEqual([['bold']]);
 	});
 
 	it('moves focus horizontally with arrow keys, Home, and End', async () => {

--- a/packages/ui/src/lib/toggle-group/types.ts
+++ b/packages/ui/src/lib/toggle-group/types.ts
@@ -15,17 +15,16 @@ export type {
 } from './root/context.svelte';
 
 export type ToggleGroupRootProps = Omit<HTMLAttributes<HTMLDivElement>, 'children' | 'class'> & {
-	/** Selected values. Two-way by default — use `bind:value`. */
+	/**
+	 * Selected values, and the source of truth whenever it is supplied — with `bind:value`
+	 * or without. Every change is written back here and reported through `onChange`; without
+	 * a binding that write only lands locally, so a parent that hears `onChange` and refuses
+	 * the change (never flowing a new `value` down) sees the group move anyway, and snap back
+	 * to the supplied `value` the next time the parent renders.
+	 */
 	value?: ToggleGroupValue[];
 	/** Initially selected values, for when `value` is not supplied. */
 	defaultValue?: ToggleGroupValue[];
-	/**
-	 * Opt into fully controlled state: the component stops writing back to `value` and
-	 * only reports through `onChange`, so the parent can reject a change by not flowing
-	 * the new value back down. Off by default, because `bind:value` — the common case —
-	 * needs the write-back to work at all.
-	 */
-	controlledValue?: boolean;
 	onChange?: (value: ToggleGroupValue[]) => void;
 	selectionMode?: ToggleGroupSelectionMode;
 	disabled?: boolean;


### PR DESCRIPTION
Two changes to who owns a `ToggleGroup`'s selection, both breaking in the same direction: `value` decides, and the group only speaks when the user acts.

## `controlledValue` is gone

It existed because `bind:value` and `value={...}` are indistinguishable at runtime, so controlled-ness could not be inferred and had to be declared. The flag bought little: the write-back reaches a binding and stays local without one — the same line either way — and a parent that owns `value` already takes the selection back on its next render.

What is left is one path. `value` is the source of truth whenever it is supplied, bound or not, and `onChange` always fires on a real interaction. A parent rejects a change by rendering, not by staying silent.

**Migration:** delete `controlledValue`. `value` + `onChange` without a binding already is the controlled case.

## No `onChange` while the group unmounts

The expensive half. A selected toggle unregisters while the group is being destroyed, `disallowEmptySelection` picked a fallback, and the consumer heard a press nobody made. Downstream, with the value bound to a URL, leaving the screen navigated straight back to it; during SSR the toggles unregister as the markup closes, so the same phantom change called `goto` mid-render and 500'd the page.

The fix has to tell that apart from a toggle genuinely leaving a group that stays mounted — still a real change, still reported. The context now has a live window, opened by the root and closed as it goes away, and only inside it does an unregistration reconcile.

It is `$effect.pre` rather than `onDestroy` because Svelte tears down an effect's children before that effect's own cleanup: created while the root's script runs, before any toggle exists, it is first in destroy order and closes the window ahead of them. On the server it never runs at all, which is the right answer there too.

## Release

Changeset is `major` — a public prop is gone. It does not move the base version: the prerelease already carries a `major` from `initial-release`, so the aggregate was already major and the base stays `1.0.0`.

## Checks

Run locally on this branch, all green: browser tests (1741 in 134 files), SSR tests (27 in 10 files), `svelte-check` on both packages (0 errors), `pnpm lint` (prettier + eslint + `todo:check`), and `pnpm build` (publint clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)