### PR TITLE
chore: release 1.0.0-beta.5

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -51,6 +51,7 @@
     "textarea-v1",
     "thin-turtles-allow",
     "tidy-planes-repair",
+    "toggle-group-owns-its-value",
     "transfer-list-filter-reorder-form",
     "transfer-list",
     "tree-v1"

--- a/docs/src/lib/docs/releases-data.json
+++ b/docs/src/lib/docs/releases-data.json
@@ -1,7 +1,23 @@
 [
 	{
+		"version": "1.0.0-beta.5",
+		"date": "2026-08-11T15:55:38.693Z",
+		"sections": [
+			{
+				"type": "Major",
+				"entries": [
+					{
+						"pr": 79,
+						"prUrl": "https://github.com/human-kit/ui/pull/79",
+						"html": "<p><strong>Breaking:</strong> remove <code>ToggleGroup.Root</code>'s <code>controlledValue</code> prop, and stop the group from reporting a selection change while it is unmounting.</p>\n<ul>\n<li><code>value</code> is the source of truth whenever it is supplied, with <code>bind:value</code> or without — there is no longer a flag to declare which. <code>onChange</code> always fires on a real interaction, and the write-back still reaches a binding.</li>\n<li>A parent that owns <code>value</code> and rejects a change still sees the group move; the supplied <code>value</code> takes the selection back on the parent's next render.</li>\n<li>Unmounting the whole group no longer fires <code>onChange</code>. Previously the selected toggle unregistered during teardown, <code>disallowEmptySelection</code> picked a fallback, and the consumer heard a press the user never made — enough to navigate a URL-backed group straight back to the screen being left. Removing a single <code>Toggle.Root</code> from a group that stays mounted still falls back and reports.</li>\n</ul>\n<p>Migration: delete <code>controlledValue</code>. <code>value</code> + <code>onChange</code> without a binding already is the controlled case.</p>"
+					}
+				]
+			}
+		]
+	},
+	{
 		"version": "1.0.0-beta.4",
-		"date": "2026-08-08T18:33:42.779Z",
+		"date": "2026-08-08T15:41:31-03:00",
 		"sections": [
 			{
 				"type": "Minor",

--- a/packages/ui/CHANGELOG.md
+++ b/packages/ui/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @human-kit/ui
 
+## 1.0.0-beta.5
+
+### Major Changes
+
+- [#79](https://github.com/human-kit/ui/pull/79) [`029028f`](https://github.com/human-kit/ui/commit/029028fdd241d8d74b728ae6270d44b2e41a924e) Thanks [@Agustin-Delgado](https://github.com/Agustin-Delgado)! - **Breaking:** remove `ToggleGroup.Root`'s `controlledValue` prop, and stop the group from reporting a selection change while it is unmounting.
+
+  - `value` is the source of truth whenever it is supplied, with `bind:value` or without — there is no longer a flag to declare which. `onChange` always fires on a real interaction, and the write-back still reaches a binding.
+  - A parent that owns `value` and rejects a change still sees the group move; the supplied `value` takes the selection back on the parent's next render.
+  - Unmounting the whole group no longer fires `onChange`. Previously the selected toggle unregistered during teardown, `disallowEmptySelection` picked a fallback, and the consumer heard a press the user never made — enough to navigate a URL-backed group straight back to the screen being left. Removing a single `Toggle.Root` from a group that stays mounted still falls back and reports.
+
+  Migration: delete `controlledValue`. `value` + `onChange` without a binding already is the controlled case.
+
 ## 1.0.0-beta.4
 
 ### Minor Changes

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@human-kit/ui",
-	"version": "1.0.0-beta.4",
+	"version": "1.0.0-beta.5",
 	"description": "Accessible, typed UI components for Svelte 5 — shipped as native ESM with per-component subpath exports so bundlers only include what you import.",
 	"license": "MIT",
 	"author": "Agustin Delgado <agustindariodelgado@gmail.com>",


### PR DESCRIPTION
Version bump produced by the Release workflow. Merging this publishes `@human-kit/ui@1.0.0-beta.5` to npm.

Consumes the changeset from #79: `ToggleGroup.Root` drops `controlledValue`, and the group no longer reports a selection change while it unmounts.

The bump is `major` and stays inside the `1.0.0` prerelease line — the base version does not move because `initial-release` already carried a major, so the aggregate was major before this.

Touches only `packages/ui/package.json`, `packages/ui/CHANGELOG.md`, `.changeset/pre.json` and the docs release timeline.