### PR TITLE
fix(release): point the beta dist-tag at every version we publish

### DIFF
--- a/scripts/publish.mjs
+++ b/scripts/publish.mjs
@@ -12,12 +12,30 @@ import { existsSync, readFileSync } from 'node:fs';
 import { execSync } from 'node:child_process';
 
 const preConfigUrl = new URL('../.changeset/pre.json', import.meta.url);
+const packageUrl = new URL('../packages/ui/package.json', import.meta.url);
+
+let pre = null;
 
 if (existsSync(preConfigUrl)) {
-	const pre = JSON.parse(readFileSync(preConfigUrl, 'utf8'));
+	pre = JSON.parse(readFileSync(preConfigUrl, 'utf8'));
 	console.log(`Prerelease mode detected: changeset will publish under the "${pre.tag}" dist-tag.`);
 } else {
 	console.log('Stable mode: publishing under npm dist-tag "latest".');
 }
 
 execSync('pnpm exec changeset publish', { stdio: 'inherit' });
+
+// While a package has never had a stable release, changesets sends the prerelease
+// to `latest` and leaves the pre tag alone — it says so itself: "being published to
+// latest rather than beta because there has not been a regular release of it yet".
+// Pointing `latest` there is right, since nothing else can hold it. Leaving the pre
+// tag behind is not: `beta` stayed on 1.0.0-beta.0 from July while six more versions
+// shipped, so `npm i @human-kit/ui@beta` installed a build months old.
+//
+// `changeset publish` REJECTS an explicit `--tag` in pre mode, so the tag is moved
+// afterwards. It is idempotent, and a no-op once the version already carries it.
+if (pre) {
+	const pkg = JSON.parse(readFileSync(packageUrl, 'utf8'));
+	console.log(`Pointing the "${pre.tag}" dist-tag at ${pkg.version}.`);
+	execSync(`npm dist-tag add ${pkg.name}@${pkg.version} ${pre.tag}`, { stdio: 'inherit' });
+}


### PR DESCRIPTION
`npm i @human-kit/ui@beta` installs `1.0.0-beta.0`, a build from July, while six more versions have shipped since.

The publish log says why:

```
@human-kit/ui is being published to latest rather than beta
because there has not been a regular release of it yet
```

Changesets sends a prerelease to `latest` while the package has no stable release, and it leaves the pre tag alone. `latest` is correct: nothing else can hold it until 1.0.0. The frozen `beta` tag is not.

`changeset publish` refuses an explicit `--tag` in prerelease mode, so `scripts/publish.mjs` moves the tag after the publish. The command is idempotent, so a rerun changes nothing.

The merge of this pull request runs `Release`, which repairs the tag as a side effect: no changesets are pending, so the workflow goes down the publishing path, `changeset publish` skips the version that is already on npm, and the new step points `beta` at `1.0.0-beta.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
