### PR TITLE
feat(docs): search the documentation

### DIFF
--- a/.changeset/autocomplete-hover-takes-focus.md
+++ b/.changeset/autocomplete-hover-takes-focus.md
@@ -1,0 +1,7 @@
+---
+'@human-kit/ui': patch
+---
+
+Let the pointer take the virtual focus in `Autocomplete`, the same as in `ComboBox`.
+
+The keys moved the virtual focus and the pointer only marked `data-hovered`, so the row the keys left behind and the row under the pointer were both current at the same time. A style bound to `data-focused` and one bound to `data-hovered` then painted two rows, and an item cannot correct that on its own: it sees only its own attributes. `Autocomplete.Item` now moves the focus to the option the pointer enters, and clears the keyboard ring, so exactly one option is current.

--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
 		"@human-kit/ui": "workspace:*",
 		"@lucide/svelte": "^0.574.0",
 		"@sveltejs/adapter-vercel": "^6.3.1",
+		"minisearch": "^7.2.0",
 		"svelte-render-scan": "^1.1.0",
 		"tailwind-variants": "^3.2.2",
 		"vite-plugin-devtools-json": "^1.0.0"
@@ -27,6 +28,7 @@
 		"@sveltejs/vite-plugin-svelte": "^6.2.1",
 		"@tailwindcss/vite": "^4.1.14",
 		"@toolwind/corner-shape": "^0.0.8-3",
+		"github-slugger": "^2.0.0",
 		"rehype-slug": "^6.0.0",
 		"svelte": "^5.41.0",
 		"svelte-check": "^4.3.4",

--- a/docs/src/lib/docs/components/docs-shell/docs-shell.svelte
+++ b/docs/src/lib/docs/components/docs-shell/docs-shell.svelte
@@ -36,7 +36,7 @@
 		brand?: Snippet;
 		/** Rendered in the header before the GitHub link and theme toggle. */
 		actions?: Snippet;
-		/** Opens the site search. Sits at the start of the header's right cluster. */
+		/** Opens the site search. Sits in the middle of the header. */
 		search?: Snippet;
 		/** Replace the whole header region. */
 		header?: Snippet;

--- a/docs/src/lib/docs/components/docs-shell/docs-shell.svelte
+++ b/docs/src/lib/docs/components/docs-shell/docs-shell.svelte
@@ -36,6 +36,8 @@
 		brand?: Snippet;
 		/** Rendered in the header before the GitHub link and theme toggle. */
 		actions?: Snippet;
+		/** Opens the site search. Sits at the start of the header's right cluster. */
+		search?: Snippet;
 		/** Replace the whole header region. */
 		header?: Snippet;
 		/** Replace the sidebar region. */
@@ -55,6 +57,7 @@
 		headings,
 		brand,
 		actions,
+		search,
 		header,
 		sidebar,
 		toc,
@@ -71,7 +74,7 @@
 		<!-- Both rails collapse on narrow screens (the sidebar below `md`, the outline
 		     below `xl`), so each gets a drawer standing in for it at exactly the width
 		     where it disappears. The triggers carry their own breakpoint classes. -->
-		<Header {title} {badge} {githubUrl} {homeHref} {brand} {actions}>
+		<Header {title} {badge} {githubUrl} {homeHref} {brand} {actions} {search}>
 			{#snippet navTrigger()}
 				<MobileNav {nav} {basePath} {actions} {githubUrl} />
 			{/snippet}

--- a/docs/src/lib/docs/components/header/header.svelte
+++ b/docs/src/lib/docs/components/header/header.svelte
@@ -22,6 +22,12 @@
 		brand?: Snippet;
 		/** Rendered before the GitHub link and theme toggle. */
 		actions?: Snippet;
+		/**
+		 * Opens the site search. It is the first thing in the right-hand cluster and
+		 * the only one that stays there on a phone: search replaces reading the
+		 * navigation, so it must not move into the drawer that navigation lives in.
+		 */
+		search?: Snippet;
 		/** Leftmost slot, before the brand — the mobile navigation opener. */
 		navTrigger?: Snippet;
 		/** Rendered at the start of the right-hand cluster — the mobile outline opener. */
@@ -36,6 +42,7 @@
 		level,
 		brand,
 		actions,
+		search,
 		navTrigger,
 		tocTrigger
 	}: Props = $props();
@@ -75,6 +82,9 @@
 	</a>
 
 	<div class="ml-auto flex items-center gap-1">
+		{#if search}
+			{@render search()}
+		{/if}
 		{#if tocTrigger}
 			{@render tocTrigger()}
 		{/if}

--- a/docs/src/lib/docs/components/header/header.svelte
+++ b/docs/src/lib/docs/components/header/header.svelte
@@ -23,9 +23,9 @@
 		/** Rendered before the GitHub link and theme toggle. */
 		actions?: Snippet;
 		/**
-		 * Opens the site search. It is the first thing in the right-hand cluster and
-		 * the only one that stays there on a phone: search replaces reading the
-		 * navigation, so it must not move into the drawer that navigation lives in.
+		 * Opens the site search. It sits in the middle of the row, and on a phone at
+		 * the head of the right-hand cluster: search replaces reading the navigation,
+		 * so it must not move into the drawer that navigation lives in.
 		 */
 		search?: Snippet;
 		/** Leftmost slot, before the brand — the mobile navigation opener. */
@@ -83,7 +83,14 @@
 
 	<div class="ml-auto flex items-center gap-1">
 		{#if search}
-			{@render search()}
+			<!-- Centred against the row from `md` up, where the brand is on the left and
+			     the middle of the row is empty. Below that the middle already holds the
+			     logo, so it stays in the flow at the head of this cluster. -->
+			<div
+				class="md:absolute md:top-0 md:bottom-0 md:left-1/2 md:flex md:-translate-x-1/2 md:items-center"
+			>
+				{@render search()}
+			</div>
 		{/if}
 		{#if tocTrigger}
 			{@render tocTrigger()}

--- a/docs/src/lib/docs/components/index.ts
+++ b/docs/src/lib/docs/components/index.ts
@@ -8,6 +8,7 @@ export { default as Header } from './header/header.svelte';
 export { default as DocToolbar } from './doc-toolbar/doc-toolbar.svelte';
 export { Menu, menuRecipe } from './menu/index.js';
 export { default as PropsTable } from './props-table/props-table.svelte';
+export { Search } from './search/index.js';
 export { default as Sidebar } from './sidebar/sidebar.svelte';
 export { Tabs, tabsRecipe } from './tabs/index.js';
 export { default as InstallCommand } from './install-command/install-command.svelte';

--- a/docs/src/lib/docs/components/search/index.ts
+++ b/docs/src/lib/docs/components/search/index.ts
@@ -1,0 +1,1 @@
+export { default as Search } from './search.svelte';

--- a/docs/src/lib/docs/components/search/search.svelte
+++ b/docs/src/lib/docs/components/search/search.svelte
@@ -1,0 +1,230 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import type MiniSearch from 'minisearch';
+	import { Autocomplete, Dialog } from '@human-kit/ui';
+	import { ChevronRight, Search as SearchIcon } from '@lucide/svelte';
+	import { goto } from '$app/navigation';
+	import { resolve } from '$app/paths';
+	import { buttonVariants } from '../button/recipe';
+	import {
+		groupHits,
+		hitLabel,
+		loadIndex,
+		searchIndex,
+		type SearchHit
+	} from '../../search/search-engine.js';
+	import type { SearchRecord } from '../../search/types.js';
+
+	interface Props {
+		/**
+		 * Loads the index. The default downloads the prebuilt file; a test passes
+		 * its own records instead of standing up the whole route.
+		 */
+		load?: () => Promise<MiniSearch<SearchRecord>>;
+	}
+
+	let { load = () => loadIndex() }: Props = $props();
+
+	let open = $state(false);
+	let query = $state('');
+	let index = $state<MiniSearch<SearchRecord> | null>(null);
+	let failed = $state(false);
+	let isApplePlatform = $state(false);
+
+	// Plain variables, not state: the effect below must not re-run when they change.
+	let loadStarted = false;
+
+	const results = $derived(index && query.trim() !== '' ? searchIndex(index, query) : []);
+	const groups = $derived(groupHits(results));
+
+	// The index is a separate download, so it waits for the reader to ask for it.
+	$effect(() => {
+		if (!open || loadStarted) return;
+		loadStarted = true;
+		load().then(
+			(loaded) => (index = loaded),
+			() => {
+				failed = true;
+				// Let the next open try again — the file may just have been unreachable.
+				loadStarted = false;
+			}
+		);
+	});
+
+	// After mount rather than during render: the server has no platform to read,
+	// and the label has to change once the client knows which key to name.
+	onMount(() => {
+		isApplePlatform = /mac|iphone|ipad|ipod/i.test(navigator.platform || navigator.userAgent);
+	});
+
+	/** A shortcut must not fire while the reader is writing somewhere else. */
+	function isTyping(target: EventTarget | null): boolean {
+		if (!(target instanceof HTMLElement)) return false;
+		return (
+			target.isContentEditable ||
+			target instanceof HTMLInputElement ||
+			target instanceof HTMLTextAreaElement ||
+			target instanceof HTMLSelectElement
+		);
+	}
+
+	function onWindowKeydown(event: KeyboardEvent) {
+		if (event.key.toLowerCase() === 'k' && (event.metaKey || event.ctrlKey)) {
+			event.preventDefault();
+			open = !open;
+			return;
+		}
+
+		// The bare slash is the second way in, and the one that costs nothing to
+		// discover. It stays out of the way of anyone who is writing.
+		if (event.key === '/' && !open && !event.metaKey && !event.ctrlKey && !event.altKey) {
+			if (isTyping(event.target)) return;
+			event.preventDefault();
+			open = true;
+		}
+	}
+
+	async function goToHit(hit: SearchHit) {
+		open = false;
+		query = '';
+		// The route goes through resolve(); only the fragment is added afterwards.
+		// eslint-disable-next-line svelte/no-navigation-without-resolve
+		await goto(`${resolve(`/docs/${hit.slug}`)}${hit.hash === '' ? '' : `#${hit.hash}`}`);
+	}
+
+	function onSelect(selection: Set<string | number>) {
+		const id = String(Array.from(selection)[0] ?? '');
+		const hit = results.find((result) => result.id === id);
+		if (hit) void goToHit(hit);
+	}
+
+	// The dialog unmounts its content, so the query only has to be cleared for the
+	// case where the reader closes without picking anything.
+	$effect(() => {
+		if (!open) query = '';
+	});
+</script>
+
+<svelte:window onkeydown={onWindowKeydown} />
+
+<Dialog.Root bind:open>
+	<Dialog.Trigger
+		class={buttonVariants({
+			variant: 'outline',
+			class: 'gap-2 sm:w-56 sm:justify-between sm:pr-1 max-sm:size-6.5 max-sm:px-0'
+		})}
+		aria-label="Search the documentation"
+	>
+		<span class="flex items-center gap-1.5">
+			<SearchIcon />
+			<span class="hidden sm:inline">Search</span>
+		</span>
+		<kbd
+			class="hidden rounded border border-border px-1 font-sans text-[10px] text-muted-foreground sm:inline"
+		>
+			{isApplePlatform ? '⌘' : 'Ctrl '}K
+		</kbd>
+	</Dialog.Trigger>
+
+	<Dialog.Portal>
+		<Dialog.Overlay class="fixed inset-0 bg-black/50" />
+		<Dialog.Content
+			class="flex max-h-[70vh] w-[36rem] max-w-[92vw] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg"
+		>
+			<!-- The dialog takes its name from the title; the search box is not it. -->
+			<Dialog.Title class="sr-only">Search the documentation</Dialog.Title>
+
+			<!-- `filter={null}`: MiniSearch already ranked and cut the list, and the
+			     local filter would hide most of it again by matching the query
+			     against the row text. -->
+			<Autocomplete.Root
+				id="docs-search"
+				inputValue={query}
+				onInputChange={(value) => (query = value)}
+				filter={null}
+				aria-label="Search the documentation"
+				class="flex min-h-0 flex-1 flex-col"
+			>
+				<div class="flex shrink-0 items-center gap-2 border-b border-border px-3">
+					<SearchIcon class="size-4 shrink-0 text-muted-foreground" />
+					<Autocomplete.Input
+						placeholder="Search documentation…"
+						aria-label="Search the documentation"
+						class="h-11 w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+					/>
+				</div>
+
+				<Autocomplete.Status
+					formatMessage={(count) =>
+						count === 0 ? 'No results' : `${count} result${count === 1 ? '' : 's'}`}
+				/>
+
+				<Autocomplete.List
+					aria-label="Search results"
+					selectionBehavior="replace"
+					onChange={onSelect}
+					class="docs-scrollbar min-h-0 flex-1 overflow-y-auto p-1.5"
+				>
+					{#each groups as group, position (group.label)}
+						{@const labelId = `docs-search-group-${position}`}
+						<div role="group" aria-labelledby={labelId}>
+							<div id={labelId} class="px-2.5 pt-2 pb-1 text-xs text-muted-foreground">
+								{group.label}
+							</div>
+							{#each group.hits as hit (hit.id)}
+								{@const path = hitLabel(hit)}
+								<!-- `data-focused`, not `data-focus-visible`: the DOM focus stays in the
+								     input, and the row the arrow keys are on is the virtually focused one. -->
+								<Autocomplete.Item
+									id={hit.id}
+									textValue={path.join(' ')}
+									class="flex cursor-default items-center gap-1 rounded-md px-2.5 py-1.5 text-sm outline-none data-[focused=true]:bg-accent data-[hovered=true]:bg-accent"
+								>
+									<!-- Keyed by the position: a section whose heading repeats the page
+									     title would give two steps the same key. -->
+									{#each path as step, depth (depth)}
+										{#if depth > 0}
+											<ChevronRight class="size-3.5 shrink-0 text-muted-foreground" />
+										{/if}
+										<span
+											class="truncate {depth === path.length - 1
+												? 'text-foreground'
+												: 'text-muted-foreground'}"
+										>
+											{step}
+										</span>
+									{/each}
+								</Autocomplete.Item>
+							{/each}
+						</div>
+					{/each}
+
+					<Autocomplete.Empty class="px-3 py-10 text-center text-sm text-muted-foreground">
+						{#if failed}
+							The search index did not load. Close this and try again.
+						{:else if query.trim() === ''}
+							Write to search the components and the guides.
+						{:else if index === null}
+							Loading…
+						{:else}
+							No results for "{query}"
+						{/if}
+					</Autocomplete.Empty>
+				</Autocomplete.List>
+			</Autocomplete.Root>
+
+			<div
+				class="flex shrink-0 items-center gap-3 border-t border-border px-3 py-2 text-xs text-muted-foreground"
+			>
+				<span class="flex items-center gap-1.5">
+					<kbd class="rounded border border-border px-1 font-sans">↵</kbd>
+					Go to page
+				</span>
+				<span class="flex items-center gap-1.5">
+					<kbd class="rounded border border-border px-1 font-sans">↑↓</kbd>
+					Move
+				</span>
+			</div>
+		</Dialog.Content>
+	</Dialog.Portal>
+</Dialog.Root>

--- a/docs/src/lib/docs/components/search/search.svelte
+++ b/docs/src/lib/docs/components/search/search.svelte
@@ -133,7 +133,7 @@
 		     edges on every keystroke, and a full list of results takes over the
 		     screen. This one only ever grows downwards, and past the cap it scrolls. -->
 		<Dialog.Content
-			class="flex max-h-[min(26rem,70vh)] w-[36rem] max-w-[92vw] flex-col self-start overflow-hidden rounded-lg border border-border bg-background shadow-lg mt-[12vh]"
+			class="flex max-h-[min(26rem,70vh)] w-[36rem] max-w-[92vw] flex-col self-start overflow-hidden rounded-xl border border-border bg-background shadow-lg mt-[12vh]"
 		>
 			<!-- The dialog takes its name from the title; the search box is not it. -->
 			<Dialog.Title class="sr-only">Search the documentation</Dialog.Title>
@@ -156,7 +156,7 @@
 					<Autocomplete.Input
 						placeholder="Search documentation…"
 						aria-label="Search the documentation"
-						class="h-11 w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
+						class="h-9 w-full bg-transparent text-sm text-foreground outline-none placeholder:text-muted-foreground"
 					/>
 				</div>
 
@@ -177,31 +177,49 @@
 							<div id={labelId} class="px-2.5 pt-2 pb-1 text-xs text-muted-foreground">
 								{group.label}
 							</div>
-							{#each group.hits as hit (hit.id)}
-								{@const path = hitLabel(hit)}
-								<!-- `data-focused`, not `data-focus-visible`: the DOM focus stays in the
-								     input, and the row the arrow keys are on is the virtually focused one. -->
-								<Autocomplete.Item
-									id={hit.id}
-									textValue={path.join(' ')}
-									class="flex cursor-default items-center gap-1 rounded-md px-2.5 py-1.5 text-sm outline-none data-[focused=true]:bg-accent data-[hovered=true]:bg-accent"
-								>
-									<!-- Keyed by the position: a section whose heading repeats the page
-									     title would give two steps the same key. -->
-									{#each path as step, depth (depth)}
-										{#if depth > 0}
-											<ChevronRight class="size-3.5 shrink-0 text-muted-foreground" />
-										{/if}
-										<span
-											class="truncate {depth === path.length - 1
-												? 'text-foreground'
-												: 'text-muted-foreground'}"
-										>
-											{step}
-										</span>
-									{/each}
-								</Autocomplete.Item>
-							{/each}
+							<!-- Same indent the sidebar gives the items of a group: the inset is
+							     padding on the container, never a margin on the rows, which are
+							     `w-full` and would overflow their rounded right edge. `pl-4` plus
+							     the row's own `px-2.5` puts the label 1rem right of the heading. -->
+							<div class="space-y-0.5 pl-4">
+								{#each group.hits as hit (hit.id)}
+									{@const path = hitLabel(hit)}
+									<!-- Same states as a ComboBox item, painted with the tokens of the
+									     chrome: the row under the pointer and the row the arrow keys are
+									     on take one fill, and `sunken` is only the press.
+
+									     Only ONE row is ever filled. `data-hovered` and `data-focused`
+									     live on different rows at the same time — the keys move one, the
+									     pointer the other — and the item cannot see that from its own
+									     attributes, so the keyboard fill asks the list whether anything is
+									     hovered. The pointer wins while it is over the list, because it is
+									     the thing the reader is moving.
+
+									     `data-focused`, not `data-focus-visible`: the DOM focus stays in
+									     the input, so no row ever takes it; the row the arrow keys are on
+									     is the virtually focused one. -->
+									<Autocomplete.Item
+										id={hit.id}
+										textValue={path.join(' ')}
+										class="flat flex cursor-default items-center gap-1 rounded-md border border-transparent px-2.5 py-1 text-sm outline-none transition-[background-color,box-shadow,border-color] ease-out [[role=listbox]:not(:has([data-hovered]))_&]:data-[focused=true]:bg-(--sink-bg) data-[hovered=true]:bg-(--sink-bg) data-[pressed=true]:sunken data-[pressed=true]:border-border data-[pressed=true]:bg-(--press-bg) data-[selected=true]:sunken data-[selected=true]:border-border data-[selected=true]:bg-(--press-bg)"
+									>
+										<!-- Keyed by the position: a section whose heading repeats the
+										     page title would give two steps the same key. -->
+										{#each path as step, depth (depth)}
+											{#if depth > 0}
+												<ChevronRight class="size-3.5 shrink-0 text-muted-foreground" />
+											{/if}
+											<span
+												class="truncate {depth === path.length - 1
+													? 'text-foreground'
+													: 'text-muted-foreground'}"
+											>
+												{step}
+											</span>
+										{/each}
+									</Autocomplete.Item>
+								{/each}
+							</div>
 						</div>
 					{/each}
 
@@ -220,7 +238,7 @@
 			</Autocomplete.Root>
 
 			<div
-				class="flex shrink-0 items-center gap-3 border-t border-border bg-depth-1 px-3 py-2 text-xs text-muted-foreground"
+				class="flex shrink-0 items-center gap-3 border-t border-border bg-depth-1 p-2 text-xs text-muted-foreground"
 			>
 				<span class="flex items-center gap-1.5">
 					<kbd class="rounded border border-border px-1 font-sans">↵</kbd>

--- a/docs/src/lib/docs/components/search/search.svelte
+++ b/docs/src/lib/docs/components/search/search.svelte
@@ -108,17 +108,17 @@
 <svelte:window onkeydown={onWindowKeydown} />
 
 <Dialog.Root bind:open>
+	<!-- No width of its own: the trigger is as wide as the words in it, so the
+	     middle of the header stays as empty as it can. -->
 	<Dialog.Trigger
 		class={buttonVariants({
 			variant: 'outline',
-			class: 'gap-2 sm:w-56 sm:justify-between sm:pr-1 max-sm:size-6.5 max-sm:px-0'
+			class: 'gap-1.5 pr-1 text-sm max-sm:size-6.5 max-sm:px-0'
 		})}
 		aria-label="Search the documentation"
 	>
-		<span class="flex items-center gap-1.5">
-			<SearchIcon />
-			<span class="hidden sm:inline">Search</span>
-		</span>
+		<SearchIcon />
+		<span class="hidden sm:inline">Search</span>
 		<kbd
 			class="hidden rounded border border-border px-1 font-sans text-[10px] text-muted-foreground sm:inline"
 		>
@@ -128,8 +128,12 @@
 
 	<Dialog.Portal>
 		<Dialog.Overlay class="fixed inset-0 bg-black/50" />
+		<!-- Near the top of the viewport rather than in the middle of it, and capped:
+		     a panel that is centred and grows with the result count moves both of its
+		     edges on every keystroke, and a full list of results takes over the
+		     screen. This one only ever grows downwards, and past the cap it scrolls. -->
 		<Dialog.Content
-			class="flex max-h-[70vh] w-[36rem] max-w-[92vw] flex-col overflow-hidden rounded-lg border border-border bg-background shadow-lg"
+			class="flex max-h-[min(26rem,70vh)] w-[36rem] max-w-[92vw] flex-col self-start overflow-hidden rounded-lg border border-border bg-background shadow-lg mt-[12vh]"
 		>
 			<!-- The dialog takes its name from the title; the search box is not it. -->
 			<Dialog.Title class="sr-only">Search the documentation</Dialog.Title>

--- a/docs/src/lib/docs/components/search/search.svelte
+++ b/docs/src/lib/docs/components/search/search.svelte
@@ -112,7 +112,7 @@
 	     middle of the header stays as empty as it can. -->
 	<Dialog.Trigger
 		class={buttonVariants({
-			variant: 'outline',
+			variant: 'ghost',
 			class: 'gap-1.5 pr-1 text-sm max-sm:size-6.5 max-sm:px-0'
 		})}
 		aria-label="Search the documentation"
@@ -149,7 +149,9 @@
 				aria-label="Search the documentation"
 				class="flex min-h-0 flex-1 flex-col"
 			>
-				<div class="flex shrink-0 items-center gap-2 border-b border-border px-3">
+				<!-- The two chrome rows sit one step deeper than the panel, so the
+				     results read as the surface and the box and the hints frame them. -->
+				<div class="flex shrink-0 items-center gap-2 border-b border-border bg-depth-1 px-3">
 					<SearchIcon class="size-4 shrink-0 text-muted-foreground" />
 					<Autocomplete.Input
 						placeholder="Search documentation…"
@@ -218,7 +220,7 @@
 			</Autocomplete.Root>
 
 			<div
-				class="flex shrink-0 items-center gap-3 border-t border-border px-3 py-2 text-xs text-muted-foreground"
+				class="flex shrink-0 items-center gap-3 border-t border-border bg-depth-1 px-3 py-2 text-xs text-muted-foreground"
 			>
 				<span class="flex items-center gap-1.5">
 					<kbd class="rounded border border-border px-1 font-sans">↵</kbd>

--- a/docs/src/lib/docs/components/search/search.svelte
+++ b/docs/src/lib/docs/components/search/search.svelte
@@ -117,7 +117,9 @@
 		})}
 		aria-label="Search the documentation"
 	>
-		<SearchIcon />
+		<!-- The icon is the whole trigger on a phone, where the word does not fit;
+		     with the word there it says nothing the word does not. -->
+		<SearchIcon class="sm:hidden" />
 		<span class="hidden sm:inline">Search</span>
 		<kbd
 			class="hidden rounded border border-border px-1 font-sans text-[10px] text-muted-foreground sm:inline"
@@ -188,12 +190,8 @@
 									     chrome: the row under the pointer and the row the arrow keys are
 									     on take one fill, and `sunken` is only the press.
 
-									     Only ONE row is ever filled. `data-hovered` and `data-focused`
-									     live on different rows at the same time — the keys move one, the
-									     pointer the other — and the item cannot see that from its own
-									     attributes, so the keyboard fill asks the list whether anything is
-									     hovered. The pointer wins while it is over the list, because it is
-									     the thing the reader is moving.
+									     One fill is enough for both: the pointer takes the virtual focus
+									     as it moves, so the hovered row IS the focused row.
 
 									     `data-focused`, not `data-focus-visible`: the DOM focus stays in
 									     the input, so no row ever takes it; the row the arrow keys are on
@@ -201,7 +199,7 @@
 									<Autocomplete.Item
 										id={hit.id}
 										textValue={path.join(' ')}
-										class="flat flex cursor-default items-center gap-1 rounded-md border border-transparent px-2.5 py-1 text-sm outline-none transition-[background-color,box-shadow,border-color] ease-out [[role=listbox]:not(:has([data-hovered]))_&]:data-[focused=true]:bg-(--sink-bg) data-[hovered=true]:bg-(--sink-bg) data-[pressed=true]:sunken data-[pressed=true]:border-border data-[pressed=true]:bg-(--press-bg) data-[selected=true]:sunken data-[selected=true]:border-border data-[selected=true]:bg-(--press-bg)"
+										class="flat flex cursor-default items-center gap-1 rounded-md border border-transparent px-2.5 py-1 text-sm outline-none transition-[background-color,box-shadow,border-color] ease-out data-[focused=true]:bg-(--sink-bg) data-[pressed=true]:sunken data-[pressed=true]:border-border data-[pressed=true]:bg-(--press-bg) data-[selected=true]:sunken data-[selected=true]:border-border data-[selected=true]:bg-(--press-bg)"
 									>
 										<!-- Keyed by the position: a section whose heading repeats the
 										     page title would give two steps the same key. -->

--- a/docs/src/lib/docs/components/search/search.test.ts
+++ b/docs/src/lib/docs/components/search/search.test.ts
@@ -1,0 +1,123 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
+import Search from './search.svelte';
+import { createIndex } from '../../search/search-engine.js';
+import type { SearchRecord } from '../../search/types.js';
+import { navigations, resetNavigations } from '../../test-stubs/app-navigation.js';
+
+const records: SearchRecord[] = [
+	{
+		id: 'button',
+		slug: 'button',
+		group: 'Form',
+		page: 'Button',
+		heading: 'Button',
+		hash: '',
+		kind: 'component',
+		text: 'A headless native button with pending semantics.'
+	},
+	{
+		id: 'button#anatomy',
+		slug: 'button',
+		group: 'Form',
+		page: 'Button',
+		heading: 'Anatomy',
+		hash: 'anatomy',
+		kind: 'section',
+		text: 'The component has one part. The part makes a native button element.'
+	},
+	{
+		id: 'drawer',
+		slug: 'drawer',
+		group: 'Overlays',
+		page: 'Drawer',
+		heading: 'Drawer',
+		hash: '',
+		kind: 'component',
+		text: 'A panel that slides in from the edge of the screen.'
+	}
+];
+
+const load = () => Promise.resolve(createIndex(records));
+
+function searchBox() {
+	return document.querySelector<HTMLElement>('[role="searchbox"]');
+}
+
+describe('Search', () => {
+	beforeEach(() => {
+		resetNavigations();
+		document.body.focus();
+	});
+
+	it('opens on the platform shortcut', async () => {
+		render(Search, { props: { load } });
+
+		await userEvent.keyboard('{Control>}k{/Control}');
+
+		await expect.poll(searchBox).not.toBeNull();
+	});
+
+	it('opens on a bare slash', async () => {
+		render(Search, { props: { load } });
+
+		await userEvent.keyboard('/');
+
+		await expect.poll(searchBox).not.toBeNull();
+	});
+
+	it('leaves the slash alone while the reader is writing somewhere else', async () => {
+		render(Search, { props: { load } });
+		const field = document.createElement('input');
+		document.body.append(field);
+		field.focus();
+
+		await userEvent.keyboard('/');
+
+		expect(searchBox()).toBeNull();
+		expect(field.value).toBe('/');
+		field.remove();
+	});
+
+	it('files the results under a heading, and reads each one as a path', async () => {
+		const screen = render(Search, { props: { load } });
+
+		await userEvent.keyboard('{Control>}k{/Control}');
+		await expect.poll(searchBox).not.toBeNull();
+		await screen.getByRole('searchbox').fill('anatomy');
+
+		await expect.poll(() => screen.getByText('Anatomy').query()).not.toBeNull();
+		// The row is "Button > Anatomy" under the "Sections" heading.
+		// The Autocomplete root is a group of its own, so this looks inside the list.
+		const group = document.querySelector('[role="listbox"] [role="group"]');
+		const labelId = group?.getAttribute('aria-labelledby');
+		expect(document.getElementById(labelId ?? '')?.textContent?.trim()).toBe('Sections');
+		await expect.poll(() => screen.getByText('Sections').query()).not.toBeNull();
+		await expect.poll(() => screen.getByText('Button').query()).not.toBeNull();
+		expect(screen.getByText('Drawer').query()).toBeNull();
+	});
+
+	it('sends the reader to the heading of the result they pick', async () => {
+		const screen = render(Search, { props: { load } });
+
+		await userEvent.keyboard('{Control>}k{/Control}');
+		await expect.poll(searchBox).not.toBeNull();
+		await screen.getByRole('searchbox').fill('anatomy');
+		await expect.poll(() => screen.getByText('Anatomy').query()).not.toBeNull();
+
+		await userEvent.keyboard('{Enter}');
+
+		await expect.poll(() => navigations).toEqual(['/docs/button#anatomy']);
+	});
+
+	it('says so when nothing matches', async () => {
+		const screen = render(Search, { props: { load } });
+
+		await userEvent.keyboard('{Control>}k{/Control}');
+		await expect.poll(searchBox).not.toBeNull();
+		await screen.getByRole('searchbox').fill('zzzz');
+
+		await expect.poll(() => screen.getByText(/No results for/).query()).not.toBeNull();
+	});
+});

--- a/docs/src/lib/docs/markdown-view.ts
+++ b/docs/src/lib/docs/markdown-view.ts
@@ -16,6 +16,7 @@
  * no filesystem access.
  */
 import type { ApiPart, ApiProp, ComponentApi } from './api-types.js';
+import { parsePageSource } from './markdown/page-source.js';
 
 const pages = import.meta.glob('/src/content/**/index.md', {
 	query: '?raw',
@@ -123,16 +124,12 @@ export function pageMarkdown(slug: string): string | null {
 
 	const imports = importMap(source, slug);
 
+	// parsePageSource drops the frontmatter (the title is already an h1), the
+	// script block and <PageActions />, and normalises the line endings every
+	// pattern below anchors on.
 	return (
-		source
-			// Every pattern below anchors on \n. A Windows checkout hands this module
-			// CRLF sources, and then the frontmatter and the script block survive
-			// into the served text as if they were page content.
-			.replace(/\r\n/g, '\n')
-			.replace(/^---\n[\s\S]*?\n---\n/, '') // frontmatter — the title is already an h1
-			.replace(/<script[\s\S]*?<\/script>\s*/, '')
-			.replace(/^[ \t]*<PageActions\s*\/>[ \t]*\n?/m, '') // renders only these very links
-			// A demo is a live example plus its source; in markdown only the source
+		parsePageSource(source)
+			.body // A demo is a live example plus its source; in markdown only the source
 			// survives, which is also the part a reader would copy.
 			.replace(/<Demo\s+source=\{([\w$]+)\}[\s\S]*?<\/Demo>/g, (whole, name: string) => {
 				const code = demos[imports[name]];

--- a/docs/src/lib/docs/markdown/page-source.ts
+++ b/docs/src/lib/docs/markdown/page-source.ts
@@ -1,0 +1,43 @@
+/**
+ * The first pass over a docs page's markdown source, shared by everything that
+ * reads `/src/content/**\/index.md` as text rather than as a component.
+ *
+ * Two readers need it — the plain-markdown view (`markdown-view.ts`) and the
+ * search index (`search/build-index.ts`) — and both of them work off `\n`
+ * anchored patterns. A Windows checkout hands them CRLF, and then the
+ * frontmatter and the `<script>` block survive into the output as if they were
+ * page content. Normalising in one place keeps that bug fixed for both.
+ */
+
+export interface PageSource {
+	/** The `title` from the frontmatter. */
+	title: string;
+	/** The `description` from the frontmatter, when the page sets one. */
+	description: string | null;
+	/** The page body: no frontmatter, no `<script>` block, no `<PageActions />`. */
+	body: string;
+}
+
+/** Reads one `key: value` line out of a frontmatter block. */
+function field(frontmatter: string, key: string): string | null {
+	const match = frontmatter.match(new RegExp(`^${key}:[ \t]*(.*)$`, 'm'));
+	if (!match) return null;
+	return match[1].trim().replace(/^['"]|['"]$/g, '') || null;
+}
+
+export function parsePageSource(raw: string): PageSource {
+	const source = raw.replace(/\r\n/g, '\n');
+	const frontmatter = source.match(/^---\n([\s\S]*?)\n---\n/);
+
+	const body = source
+		.replace(/^---\n[\s\S]*?\n---\n/, '')
+		.replace(/<script[\s\S]*?<\/script>\s*/, '')
+		// Renders the "view as markdown" links, which are page chrome rather than content.
+		.replace(/^[ \t]*<PageActions\s*\/>[ \t]*\n?/m, '');
+
+	return {
+		title: (frontmatter && field(frontmatter[1], 'title')) ?? '',
+		description: frontmatter ? field(frontmatter[1], 'description') : null,
+		body
+	};
+}

--- a/docs/src/lib/docs/search/build-index.test.ts
+++ b/docs/src/lib/docs/search/build-index.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import { render } from 'vitest-browser-svelte';
+import type { Component } from 'svelte';
+import { buildSearchIndex } from './build-index.js';
+
+const records = buildSearchIndex();
+
+/** The rendered page, to check the index against what the reader actually gets. */
+const pageModules = import.meta.glob('/src/content/**/index.md') as Record<
+	string,
+	() => Promise<{ default: Component }>
+>;
+
+async function renderedIds(slug: string): Promise<Set<string>> {
+	const module = await pageModules[`/src/content/${slug}/index.md`]();
+	const { container } = render(module.default);
+	return new Set(Array.from(container.querySelectorAll('[id]')).map((element) => element.id));
+}
+
+describe('buildSearchIndex', () => {
+	it('gives every content page one page record', () => {
+		const pageRecords = records.filter(
+			(record) => record.kind === 'component' || record.kind === 'guide'
+		);
+		expect(pageRecords.length).toBeGreaterThan(20);
+		expect(new Set(pageRecords.map((record) => record.slug)).size).toBe(pageRecords.length);
+		expect(pageRecords.every((record) => record.hash === '')).toBe(true);
+	});
+
+	it('titles the page record from the frontmatter, and says what kind of page it is', () => {
+		const button = records.find((record) => record.id === 'button');
+		expect(button?.page).toBe('Button');
+		expect(button?.group).toBe('Form');
+		expect(button?.kind).toBe('component');
+		expect(records.find((record) => record.id === 'quick-start')?.kind).toBe('guide');
+	});
+
+	it('keeps the frontmatter, the script block and the code fences out of the text', () => {
+		for (const record of records) {
+			expect(record.text).not.toContain('import ');
+			expect(record.text).not.toContain('</script>');
+			expect(record.text).not.toContain('```');
+			expect(record.text).not.toMatch(/^title:/m);
+		}
+	});
+
+	// Rendering a docs page pulls in its demos and the syntax highlighter, so the
+	// first transform of it is slow. It is worth it: nothing else proves the
+	// hashes in the index are ids that exist.
+	it('keeps the word an inline code span is about', () => {
+		// The sentence is "The part makes a native `<button>` element". Stripping the
+		// markup before the backticks took `button` out of it with the tag.
+		expect(records.find((record) => record.id === 'button#anatomy')?.text).toContain('button');
+	});
+
+	it('sends every section of a page to an id that page renders', { timeout: 60_000 }, async () => {
+		const ids = await renderedIds('button');
+		const hashes = records
+			.filter((record) => record.slug === 'button' && record.hash !== '')
+			.map((record) => record.hash);
+
+		expect(hashes.length).toBeGreaterThan(3);
+		for (const hash of hashes) expect(ids).toContain(hash);
+	});
+
+	it('indexes an API part under the id <ApiReference> renders for it', () => {
+		const root = records.find((record) => record.id === 'button#api-root');
+		expect(root?.kind).toBe('api');
+		expect(root?.heading).toBe('Root');
+		// The props and their descriptions are what a reader searches the API for.
+		expect(root?.text).toContain('pending');
+	});
+});

--- a/docs/src/lib/docs/search/build-index.ts
+++ b/docs/src/lib/docs/search/build-index.ts
@@ -1,0 +1,173 @@
+/**
+ * Builds the search index from the docs content at build time.
+ *
+ * The site is fully prerendered, so there is no server to ask at run time: the
+ * index is a static JSON file (see `routes/search-index.json`) that the client
+ * downloads the first time the reader opens the search dialog.
+ *
+ * Everything is bundled through `import.meta.glob`, the same way
+ * `markdown-view.ts` reads the pages, so this works with no filesystem access.
+ */
+import GithubSlugger from 'github-slugger';
+import type { ComponentApi } from '../api-types.js';
+import { parsePageSource } from '../markdown/page-source.js';
+import { groupOf, isComponentSlug } from '../seo.js';
+import type { SearchRecord } from './types.js';
+
+const pages = import.meta.glob('/src/content/**/index.md', {
+	query: '?raw',
+	import: 'default',
+	eager: true
+}) as Record<string, string>;
+
+const apis = import.meta.glob('/src/content/**/api.json', { eager: true }) as Record<
+	string,
+	{ default: ComponentApi }
+>;
+
+/**
+ * Markdown to plain words.
+ *
+ * Fenced code goes first, and it goes for two reasons: a `#` comment inside a
+ * fence would open a section that does not exist, and the API names a reader
+ * searches for are already indexed from `api.json` with their descriptions
+ * attached — indexing them a second time as sample code only adds noise.
+ */
+function plainText(markdown: string): string {
+	return (
+		markdown
+			.replace(/```[\s\S]*?```/g, ' ')
+			.replace(/<Demo[\s\S]*?<\/Demo>/g, ' ')
+			// Inline code before the tags: half of it is markup (`<button>`), and the
+			// tag pass below would take the one word the sentence was about with it.
+			.replace(/`([^`]*)`/g, (_whole, code: string) => ` ${code.replace(/[<>/]/g, ' ')} `)
+			.replace(/<[^>]+>/g, ' ')
+			.replace(/!\[([^\]]*)\]\([^)]*\)/g, ' ')
+			.replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+			.replace(/[*_~|]/g, ' ')
+			.replace(/^\s*[-+]\s+/gm, ' ')
+			.replace(/\s+/g, ' ')
+			// Unpadding what the passes above padded, so the text does not read
+			// "the modal prop , which".
+			.replace(/\s+([,.;:!?)\]])/g, '$1')
+			.replace(/([([])\s+/g, '$1')
+			.trim()
+	);
+}
+
+/** The heading text as a reader sees it — what rehype-slug slugs. */
+function headingText(markdown: string): string {
+	return plainText(markdown);
+}
+
+interface Section {
+	heading: string;
+	hash: string;
+	depth: number;
+	lines: string[];
+}
+
+/**
+ * Splits a page body into its headed sections.
+ *
+ * The hashes come from the same slugger rehype-slug uses, fed the headings in
+ * document order, so a result links to an id that exists on the page. A slugger
+ * per page, because that is the scope rehype-slug dedupes in.
+ */
+function sectionsOf(body: string): Section[] {
+	const slugger = new GithubSlugger();
+	const withoutCode = body.replace(/```[\s\S]*?```/g, '');
+	const sections: Section[] = [];
+
+	for (const line of withoutCode.split('\n')) {
+		const heading = line.match(/^(#{1,6})\s+(.*?)\s*$/);
+		if (heading) {
+			const text = headingText(heading[2]);
+			sections.push({
+				heading: text,
+				hash: slugger.slug(text),
+				depth: heading[1].length,
+				lines: []
+			});
+		} else if (sections.length > 0) {
+			sections[sections.length - 1].lines.push(line);
+		}
+	}
+
+	return sections;
+}
+
+function apiRecords(slug: string, page: string, group: string | null, api: ComponentApi) {
+	return api.parts.map((part): SearchRecord => {
+		const text = plainText(
+			[
+				part.description,
+				...part.props.map((prop) =>
+					[prop.name, prop.type, prop.default ?? '', prop.description].join(' ')
+				),
+				...part.dataAttributes.map((attribute) => `${attribute.name} ${attribute.description}`)
+			].join(' ')
+		);
+
+		return {
+			id: `${slug}#api-${part.name.toLowerCase()}`,
+			slug,
+			group,
+			page,
+			heading: part.name,
+			// The id <ApiReference> gives each part's heading.
+			hash: `api-${part.name.toLowerCase()}`,
+			kind: 'api',
+			text
+		};
+	});
+}
+
+export function buildSearchIndex(): SearchRecord[] {
+	const records: SearchRecord[] = [];
+
+	for (const [path, raw] of Object.entries(pages)) {
+		const slug = path.slice('/src/content/'.length, -'/index.md'.length);
+		const { title, description, body } = parsePageSource(raw);
+		const group = groupOf(slug);
+		const sections = sectionsOf(body);
+
+		// The h1 opens the page, so its section is the page record: it is what a
+		// reader means by "the Button page", and it links to the page with no hash.
+		const [intro, ...rest] = sections;
+		const introText = plainText(intro?.lines.join('\n') ?? '');
+		records.push({
+			id: slug,
+			slug,
+			group,
+			page: title,
+			heading: title,
+			hash: '',
+			// A component page and a guide answer different questions, and the dialog
+			// files them under headings of their own.
+			kind: isComponentSlug(slug) ? 'component' : 'guide',
+			text: [description ?? '', introText].join(' ').trim()
+		});
+
+		for (const section of rest) {
+			const text = plainText(section.lines.join('\n'));
+			// A heading with nothing under it still names a real destination, so it
+			// stays: the heading itself is the part that matches.
+			records.push({
+				id: `${slug}#${section.hash}`,
+				slug,
+				group,
+				page: title,
+				heading: section.heading,
+				hash: section.hash,
+				kind: 'section',
+				text
+			});
+		}
+
+		const api = apis[`/src/content/${slug}/api.json`]?.default;
+		if (api) records.push(...apiRecords(slug, title, group, api));
+	}
+
+	return records;
+}

--- a/docs/src/lib/docs/search/search-engine.test.ts
+++ b/docs/src/lib/docs/search/search-engine.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { buildSearchIndex } from './build-index.js';
+import { createIndex, groupHits, hitLabel, searchIndex } from './search-engine.js';
+
+// The real index: a ranking test against a fixture proves nothing about the
+// site the reader searches.
+const index = createIndex(buildSearchIndex());
+
+function top(query: string) {
+	return searchIndex(index, query)[0];
+}
+
+describe('searchIndex', () => {
+	it('finds nothing for an empty query', () => {
+		expect(searchIndex(index, '')).toEqual([]);
+		expect(searchIndex(index, '   ')).toEqual([]);
+	});
+
+	it('puts the section that is about the word first', () => {
+		expect(top('pending').slug).toBe('button');
+		expect(top('install').slug).toBe('quick-start');
+	});
+
+	it('finds a prop by name, in the API part that documents it', () => {
+		const hit = top('focusableWhenDisabled');
+		expect(hit.id).toBe('button#api-root');
+		expect(hit.kind).toBe('api');
+	});
+
+	it('answers a component name with the page, not with its API rows', () => {
+		// There are more API records than prose ones and their headings repeat
+		// across components, so without the per-kind weighting they win this.
+		expect(top('accordion').id).toBe('accordion');
+		expect(top('accordion').kind).toBe('component');
+	});
+
+	it('matches a word the reader has not finished writing', () => {
+		expect(top('accord').slug).toBe('accordion');
+	});
+
+	it('requires every complete word to match', () => {
+		const hits = searchIndex(index, 'date range');
+		expect(hits.length).toBeGreaterThan(0);
+		expect(hits[0].slug).toBe('daterangepicker');
+	});
+
+	it('shows at most one screenful of results', () => {
+		expect(searchIndex(index, 'the').length).toBeLessThanOrEqual(20);
+	});
+});
+
+describe('groupHits', () => {
+	it('files the results under one heading per kind', () => {
+		const groups = groupHits(searchIndex(index, 'accordion'));
+		expect(groups[0].label).toBe('Components');
+		expect(groups.map((group) => group.label)).toContain('API reference');
+		expect(new Set(groups.map((group) => group.label)).size).toBe(groups.length);
+	});
+
+	it('leads with the heading that holds the best result', () => {
+		// Nothing named "focus trap" is a page, so the sections must not sit below
+		// the API rows that merely mention the words.
+		expect(groupHits(searchIndex(index, 'focus trap'))[0].label).toBe('Sections');
+	});
+});
+
+describe('hitLabel', () => {
+	it('reads a result as the path to it', () => {
+		expect(hitLabel({ page: 'Button', heading: 'Button', hash: '' } as never)).toEqual(['Button']);
+		expect(hitLabel({ page: 'Button', heading: 'Anatomy', hash: 'anatomy' } as never)).toEqual([
+			'Button',
+			'Anatomy'
+		]);
+	});
+});

--- a/docs/src/lib/docs/search/search-engine.ts
+++ b/docs/src/lib/docs/search/search-engine.ts
@@ -1,0 +1,142 @@
+/**
+ * The client half of the docs search: it turns the prebuilt index into ranked
+ * results.
+ *
+ * MiniSearch does the ranking. The index ships as plain records rather than as
+ * a serialized MiniSearch index, because the serialized form is larger than the
+ * records it comes from and the records index in a few milliseconds anyway.
+ */
+import MiniSearch from 'minisearch';
+import type { SearchRecord } from './types.js';
+
+export interface SearchHit {
+	id: string;
+	slug: string;
+	page: string;
+	group: string | null;
+	heading: string;
+	hash: string;
+	kind: SearchRecord['kind'];
+}
+
+/** Results under the heading they are filed below in the dialog. */
+export interface SearchGroup {
+	label: string;
+	hits: SearchHit[];
+}
+
+/** How many results the dialog shows. Past this nobody is reading. */
+const RESULT_LIMIT = 20;
+
+/**
+ * A whole page outranks one of its sections, and both outrank an API part.
+ *
+ * Without this the API records win almost everything, because there are more of
+ * them and their headings are the same handful of words across every component:
+ * a reader who types "root" wants the concept, not 29 identical `Root` rows.
+ */
+const KIND_WEIGHT: Record<SearchRecord['kind'], number> = {
+	component: 1.6,
+	guide: 1.6,
+	section: 1.25,
+	api: 1
+};
+
+const KIND_LABEL: Record<SearchRecord['kind'], string> = {
+	component: 'Components',
+	guide: 'Guides',
+	api: 'API reference',
+	section: 'Sections'
+};
+
+export function createIndex(records: SearchRecord[]): MiniSearch<SearchRecord> {
+	const index = new MiniSearch<SearchRecord>({
+		idField: 'id',
+		fields: ['page', 'heading', 'text'],
+		storeFields: ['slug', 'page', 'group', 'heading', 'hash', 'kind']
+	});
+	index.addAll(records);
+	return index;
+}
+
+export function searchIndex(index: MiniSearch<SearchRecord>, query: string): SearchHit[] {
+	const trimmed = query.trim();
+	if (trimmed === '') return [];
+
+	return index
+		.search(trimmed, {
+			// The title of the page and the heading of the section say what the
+			// section is about; the body only mentions it.
+			boost: { page: 3, heading: 2 },
+			// Readers search while they type, so a half-typed word has to match.
+			prefix: true,
+			// Only the last word is still being typed, so only that one gets the
+			// benefit of the doubt on a typo. Fuzzing a complete word turns
+			// "table" into a match for "tabs".
+			fuzzy: (term, index, terms) => (index === terms.length - 1 ? 0.2 : false),
+			combineWith: 'AND',
+			boostDocument: (_id, _term, stored) => KIND_WEIGHT[stored?.kind as SearchRecord['kind']] ?? 1
+		})
+		.slice(0, RESULT_LIMIT)
+		.map((result) => ({
+			id: String(result.id),
+			slug: result.slug,
+			page: result.page,
+			group: result.group,
+			heading: result.heading,
+			hash: result.hash,
+			kind: result.kind
+		}));
+}
+
+/**
+ * Files the results under one heading per kind, keeping each list in the order
+ * the ranking put it.
+ *
+ * The headings follow the best result rather than a fixed order: with a fixed
+ * one, a query whose best answer is a section reads it below every API row that
+ * merely mentions the word.
+ */
+export function groupHits(hits: SearchHit[]): SearchGroup[] {
+	const groups = new Map<SearchRecord['kind'], SearchHit[]>();
+	for (const hit of hits) {
+		const bucket = groups.get(hit.kind);
+		if (bucket) bucket.push(hit);
+		else groups.set(hit.kind, [hit]);
+	}
+
+	return Array.from(groups, ([kind, groupHits]) => ({
+		label: KIND_LABEL[kind],
+		hits: groupHits
+	}));
+}
+
+/**
+ * A result row reads as a path: the page, then the part of it. A page is its own
+ * destination, so it is only its title.
+ */
+export function hitLabel(hit: SearchHit): string[] {
+	return hit.hash === '' ? [hit.page] : [hit.page, hit.heading];
+}
+
+let pending: Promise<MiniSearch<SearchRecord>> | null = null;
+
+/**
+ * Downloads and indexes the search index, once per session. A failed attempt
+ * clears the cache so that opening the dialog again retries instead of showing
+ * the same error forever.
+ */
+export function loadIndex(fetcher: typeof fetch = fetch): Promise<MiniSearch<SearchRecord>> {
+	pending ??= fetcher('/search-index.json')
+		.then((response) => {
+			if (!response.ok) throw new Error(`Search index: HTTP ${response.status}`);
+			return response.json() as Promise<SearchRecord[]>;
+		})
+		.then(createIndex)
+		.catch((error: unknown) => {
+			pending = null;
+			throw error;
+		});
+
+	return pending;
+}

--- a/docs/src/lib/docs/search/types.ts
+++ b/docs/src/lib/docs/search/types.ts
@@ -1,0 +1,30 @@
+/**
+ * What a search result points at.
+ *
+ * A component page and a guide are the same kind of destination, but they are
+ * not the same kind of answer, so the index tells them apart: the dialog files
+ * results under a heading per kind, the way Base UI's does.
+ */
+export type SearchKind = 'component' | 'guide' | 'section' | 'api';
+
+/**
+ * One entry of the search index. A page is many records, because a page is not
+ * a useful destination on its own: the reader wants the section that answers
+ * the question, and every record carries the hash that lands there.
+ */
+export interface SearchRecord {
+	/** `button#anatomy` — unique across the site. */
+	id: string;
+	slug: string;
+	/** The nav group the page sits in, e.g. `Form`. */
+	group: string | null;
+	/** The page title, e.g. `Button`. */
+	page: string;
+	/** The section heading, the API part, or the page title for a page record. */
+	heading: string;
+	/** The fragment to land on. Empty for a page record. */
+	hash: string;
+	kind: SearchKind;
+	/** Everything the section says, flattened to plain text. Searched, not shown. */
+	text: string;
+}

--- a/docs/src/lib/docs/test-stubs/app-navigation.ts
+++ b/docs/src/lib/docs/test-stubs/app-navigation.ts
@@ -1,0 +1,12 @@
+// Test stub for `$app/navigation`. SvelteKit's router is not running under
+// vitest, so `goto` only records where the component tried to send the reader.
+export const navigations: string[] = [];
+
+export function goto(url: string): Promise<void> {
+	navigations.push(url);
+	return Promise.resolve();
+}
+
+export function resetNavigations(): void {
+	navigations.length = 0;
+}

--- a/docs/src/routes/docs/+layout.svelte
+++ b/docs/src/routes/docs/+layout.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { DocsShell } from '$lib/docs/components/index.js';
+	import { DocsShell, Search } from '$lib/docs/components/index.js';
 	import Logo from '$lib/docs/components/icons/logo.svelte';
 	import Npm from '$lib/docs/components/icons/npm.svelte';
 	import { buttonVariants } from '$lib/docs/components/button/recipe';
@@ -16,6 +16,9 @@
 <!-- `title` is no longer painted — with a brand snippet it becomes the home
      link's accessible name. -->
 <DocsShell {nav} title="@human-kit/ui" githubUrl="https://github.com/human-kit/ui">
+	{#snippet search()}
+		<Search />
+	{/snippet}
 	{#snippet brand()}
 		<Logo class="h-4 w-auto" />
 	{/snippet}

--- a/docs/src/routes/search-index.json/+server.ts
+++ b/docs/src/routes/search-index.json/+server.ts
@@ -1,0 +1,12 @@
+import { buildSearchIndex } from '$lib/docs/search/build-index.js';
+
+// The docs are prerendered, so the index is written once at build time and
+// served as a static file. The search dialog fetches it on first open, which
+// keeps it out of every page's bundle.
+export const prerender = true;
+
+export function GET() {
+	return new Response(JSON.stringify(buildSearchIndex()), {
+		headers: { 'content-type': 'application/json' }
+	});
+}

--- a/docs/vitest.config.ts
+++ b/docs/vitest.config.ts
@@ -14,10 +14,14 @@ export default defineConfig({
 		globals: true,
 		alias: {
 			'@human-kit/ui': resolve(__dirname, '../packages/ui/src/lib'),
+			// SvelteKit's own alias, which the docs content uses to reach the
+			// components a page renders (<Demo>, <ApiReference>).
+			$lib: resolve(__dirname, 'src/lib'),
 			// SvelteKit isn't loaded under vitest, so `$app/*` is stubbed (see
 			// src/lib/docs/test-stubs). Lets components that read the route/theme render.
 			'$app/environment': resolve(__dirname, 'src/lib/docs/test-stubs/app-environment.ts'),
 			'$app/paths': resolve(__dirname, 'src/lib/docs/test-stubs/app-paths.ts'),
+			'$app/navigation': resolve(__dirname, 'src/lib/docs/test-stubs/app-navigation.ts'),
 			'$app/state': resolve(__dirname, 'src/lib/docs/test-stubs/app-state.svelte.ts')
 		},
 		browser: {

--- a/packages/ui/src/lib/autocomplete/item/autocomplete-item.svelte
+++ b/packages/ui/src/lib/autocomplete/item/autocomplete-item.svelte
@@ -112,6 +112,15 @@
 		if (isVisibleRegistered) ctx.unregisterVisibleItem(id);
 	});
 
+	function handleHoverStart(itemId: string | number) {
+		// The pointer takes the virtual focus, the same as in a ComboBox. Without
+		// this the keys move one row and the pointer marks another, and both read
+		// as the current one at the same time — which the item cannot correct on
+		// its own, because it only sees its own attributes.
+		ctx.setFocusVisible(false);
+		ctx.setFocusedItemId(itemId);
+	}
+
 	function handleSelect(itemId: string | number) {
 		if (ctx.isReadOnly) return;
 		// Selection here is pointer-driven (click); clear the keyboard focus ring.
@@ -136,6 +145,7 @@
 		isFocusVisibleOverride={isFocusVisible}
 		onItemSelect={handleSelect}
 		onResolvedTextValue={handleResolvedTextValue}
+		onItemHoverStart={handleHoverStart}
 		scrollOnFocus={true}
 		isParentDisabled={ctx.isDisabled}
 	/>

--- a/packages/ui/src/lib/autocomplete/root/autocomplete.test.ts
+++ b/packages/ui/src/lib/autocomplete/root/autocomplete.test.ts
@@ -183,17 +183,31 @@ describe('Autocomplete', () => {
 			return screen.getByText(text).element().closest('[role="option"]') as HTMLElement;
 		}
 
-		it('hovering a non-active option marks it data-hovered, never data-focused', async () => {
-			const screen = render(AutocompleteTest, { autoHighlight: false });
+		it('moves the virtual focus to the hovered option, and off the one the keys left', async () => {
+			const screen = render(AutocompleteTest);
 			const input = screen.getByRole('searchbox');
 
 			await input.click();
 			await input.fill('a');
+			await userEvent.keyboard('{ArrowDown}');
+
+			const banana = optionFor(screen, 'Banana');
+			await expect.poll(() => banana.getAttribute('data-focused')).toBe('true');
+
 			await screen.getByText('Mango').hover();
 
+			// One option is current at a time. The pointer and the keys each move the
+			// same virtual focus, so a row the keys left behind cannot stay marked
+			// while the pointer marks another one.
 			const mango = optionFor(screen, 'Mango');
 			await expect.poll(() => mango.getAttribute('data-hovered')).toBe('true');
-			expect(mango.hasAttribute('data-focused')).toBe(false);
+			await expect.poll(() => mango.getAttribute('data-focused')).toBe('true');
+			await expect.poll(() => banana.hasAttribute('data-focused')).toBe(false);
+			// A pointer never draws the keyboard ring.
+			expect(mango.hasAttribute('data-focus-visible')).toBe(false);
+			await expect
+				.poll(() => (input.element() as HTMLElement).getAttribute('aria-activedescendant'))
+				.toBe(mango.id);
 		});
 
 		it('clicking an option leaves the input without focus markers (the option is focused)', async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@sveltejs/adapter-vercel':
         specifier: ^6.3.1
         version: 6.3.4(@sveltejs/kit@2.69.0(@sveltejs/vite-plugin-svelte@6.2.4(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))(svelte@5.56.4(@typescript-eslint/types@8.62.1))(typescript@5.9.3)(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0)))(rollup@4.62.2)
+      minisearch:
+        specifier: ^7.2.0
+        version: 7.2.0
       svelte-render-scan:
         specifier: ^1.1.0
         version: 1.1.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))
@@ -145,6 +148,9 @@ importers:
       '@toolwind/corner-shape':
         specifier: ^0.0.8-3
         version: 0.0.8-3
+      github-slugger:
+        specifier: ^2.0.0
+        version: 2.0.0
       rehype-slug:
         specifier: ^6.0.0
         version: 6.0.0
@@ -1451,6 +1457,7 @@ packages:
   eslint@9.39.4:
     resolution: {integrity: sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -2027,6 +2034,9 @@ packages:
   minipass@7.1.3:
     resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  minisearch@7.2.0:
+    resolution: {integrity: sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==}
 
   minizlib@3.1.0:
     resolution: {integrity: sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==}
@@ -4889,6 +4899,8 @@ snapshots:
       brace-expansion: 2.1.1
 
   minipass@7.1.3: {}
+
+  minisearch@7.2.0: {}
 
   minizlib@3.1.0:
     dependencies:


### PR DESCRIPTION
Search on the documentation site, and the library fix it found.

## The search

The site is fully prerendered, so there is no server to ask: the index is a static file that the client downloads the first time the reader opens the dialog. MiniSearch ranks the records in the browser.

- `search/build-index.ts` turns every page, every section of a page and every API part into a record with the hash that lands on it. 381 records over 29 pages.
- `routes/search-index.json` prerenders that index. It is 288 kB, and 57 kB over the wire. Nothing of it is in the bundle of a page nobody searches from.
- The dialog is the library's own `Dialog` and `Autocomplete`. The search of a component library is the place to find out what its own components cannot do.

Results are filed under one heading per kind — Components, Guides, Sections, API reference — and each row reads as a path (`ComboBox > Anatomy`). The headings follow the best result rather than a fixed order: with a fixed order, a query whose best answer is a section reads it below every API row that only mentions the words.

`Ctrl`/`Cmd` + `K` and `/` open the dialog. Neither fires while the reader writes somewhere else.

## The library fix

The rows showed the defect: the keys moved the virtual focus, the pointer only marked `data-hovered`, and both rows read as current at the same time. Worse than the two highlights, `aria-activedescendant` stayed on the first, so `Enter` took a row other than the one the pointer marked.

`ComboBox` already solved this: `ComboBox.Item` passes `onItemHoverStart` and `ListBoxItem` moves the focus from there. `Autocomplete.Item` now does the same.

This replaces the rule a test called "single-source focus": an option was never focused by hover, which kept one attribute per item honest but left two rows current across items. An item cannot correct that on its own, because it sees only its own attributes. **If that parity was deliberate, say so and it goes back, or behind a prop.**

## Tests

- The hashes come from the slugger `rehype-slug` uses, and a test renders a page to check the index against the ids that page really has.
- Ranking fixtures run against the real index, not a fixture one.
- The dialog opens on the shortcut, stays quiet while the reader writes in a field, and sends the reader to the heading of the result they pick.
- 341 tests of `listbox`, `combobox` and `autocomplete` pass with the new focus behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
