### PR TITLE
fix(a11y): follow the modality while an element holds focus

### DIFF
--- a/.changeset/focus-visible-modality.md
+++ b/.changeset/focus-visible-modality.md
@@ -1,0 +1,5 @@
+---
+'@human-kit/ui': patch
+---
+
+Bring the focus ring back when a key press follows a pointer press. `Button`, `Checkbox`, `Switch` and `Toggle` read the interaction modality only when they take focus, so the ring stayed off for the rest of that focus, while the browser had already flipped `:focus-visible` back on. They now follow the modality for as long as they hold focus, which is what React Aria and Base UI do.

--- a/packages/ui/src/lib/button/root/button-root.svelte
+++ b/packages/ui/src/lib/button/root/button-root.svelte
@@ -5,6 +5,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import { cn } from '../../utils/cn';
 
 	export type ButtonRenderState = {
@@ -120,6 +121,14 @@
 	let pressed = $state(false);
 	let focused = $state(false);
 	let focusVisible = $state(false);
+
+	// The focus ring must appear when a pointer press is followed by a key press, and the
+	// modality alone changes there — no focus event fires to re-read it.
+	watchFocusVisible({
+		isFocused: () => focused,
+		element: () => buttonRef,
+		set: (visible) => (focusVisible = visible)
+	});
 	let pressedKey: 'Enter' | 'Space' | null = $state(null);
 	let expandedPressed = $state(false);
 

--- a/packages/ui/src/lib/button/root/button.test.ts
+++ b/packages/ui/src/lib/button/root/button.test.ts
@@ -213,4 +213,16 @@ describe('Button.Root', () => {
 		expect(button?.getAttribute('data-hovered')).toBeNull();
 		expect(button?.getAttribute('data-focused')).toBe('true');
 	});
+	// The modality can change while the element already holds focus, and no focus event fires
+	// there. React Aria and Base UI both bring the ring back on that key press.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		const screen = render(ButtonTest);
+		const element = screen.getByRole('button', { name: 'Save' }).element() as HTMLElement;
+		element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+		element.focus();
+		await expect.poll(() => element.getAttribute('data-focused')).toBe('true');
+		expect(element.hasAttribute('data-focus-visible')).toBe(false);
+		await userEvent.keyboard('a');
+		await expect.poll(() => element.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/checkbox/root/checkbox-root.svelte
+++ b/packages/ui/src/lib/checkbox/root/checkbox-root.svelte
@@ -5,6 +5,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import { setCheckboxContext, type CheckboxContext, type CheckboxState } from './context';
 
 	type CheckboxRootProps = Omit<
@@ -191,6 +192,14 @@
 	const currentChecked = $derived(currentState === 'checked');
 	const currentIndeterminate = $derived(currentState === 'indeterminate');
 	const currentUnchecked = $derived(currentState === 'unchecked');
+
+	// The focus ring must appear when a pointer press is followed by a key press, and the modality
+	// alone changes there — no focus event fires to re-read it.
+	watchFocusVisible({
+		isFocused: () => focused,
+		element: () => rootRef,
+		set: (visible) => (focusVisible = visible)
+	});
 
 	function clearPressState() {
 		pressed = false;

--- a/packages/ui/src/lib/checkbox/root/checkbox.test.ts
+++ b/packages/ui/src/lib/checkbox/root/checkbox.test.ts
@@ -322,4 +322,27 @@ describe('Checkbox.Root', () => {
 
 		expect(blurs).toBe(1);
 	});
+	// The modality can change while the element already holds focus, and no focus event fires
+	// there. React Aria and Base UI both bring the ring back on that key press.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		const screen = render(CheckboxTest);
+		const checkbox = screen.getByRole('checkbox', { name: 'Accept terms' });
+		const element = checkbox.element() as HTMLElement;
+
+		// Dispatched rather than driven through `userEvent`: the element has no size without the
+		// stylesheet, and the point here is the modality, not the hit area.
+		element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+		element.focus();
+
+		await expect.poll(() => element.getAttribute('data-focused')).toBe('true');
+		expect(element.hasAttribute('data-focus-visible')).toBe(false);
+
+		// A key the checkbox does not handle: the ring must come from the modality change alone.
+		await userEvent.keyboard('{ArrowDown}');
+		await expect.poll(() => element.getAttribute('data-focus-visible')).toBe('true');
+
+		// And it goes back off when the pointer takes over again.
+		element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+		await expect.poll(() => element.hasAttribute('data-focus-visible')).toBe(false);
+	});
 });

--- a/packages/ui/src/lib/primitives/focus-visible.svelte.ts
+++ b/packages/ui/src/lib/primitives/focus-visible.svelte.ts
@@ -1,0 +1,24 @@
+import { shouldShowFocusVisible, subscribeInputModality } from './input-modality.js';
+
+/**
+ * Keeps a `focusVisible` value honest while the element holds focus.
+ *
+ * `shouldShowFocusVisible` reads the modality at the moment it is called, so a component that
+ * only calls it from its focus handler holds a snapshot. A pointer press seeds `false`, and a
+ * key press after it flips the modality — and the `:focus-visible` of the browser — with nothing
+ * to tell the component. This subscribes for as long as the element has focus, and it re-reads
+ * on each change, which is what React Aria and Base UI do.
+ */
+export function watchFocusVisible(options: {
+	isFocused: () => boolean;
+	element: () => HTMLElement | null;
+	set: (focusVisible: boolean) => void;
+}) {
+	$effect(() => {
+		if (!options.isFocused()) return;
+
+		return subscribeInputModality(() => {
+			options.set(shouldShowFocusVisible(options.element()));
+		});
+	});
+}

--- a/packages/ui/src/lib/primitives/index.ts
+++ b/packages/ui/src/lib/primitives/index.ts
@@ -7,5 +7,6 @@ export * from './scroll-lock.js';
 export * from './aria-hide-outside.js';
 export * from './click-outside.js';
 export * from './input-modality.js';
+export * from './focus-visible.svelte.js';
 export * from './long-press.js';
 export * from './swipe-gesture.js';

--- a/packages/ui/src/lib/primitives/input-modality.ts
+++ b/packages/ui/src/lib/primitives/input-modality.ts
@@ -13,6 +13,21 @@ let lastInputEventTime = Number.NEGATIVE_INFINITY;
 
 const listenedWindows = new WeakSet<Window>();
 
+/**
+ * Notified whenever the modality changes. `data-focus-visible` is otherwise a snapshot taken
+ * when the element took focus, so a pointer press followed by a key press left the ring off
+ * while the browser had already flipped `:focus-visible` back on.
+ */
+const modalityListeners = new Set<(modality: InputModality) => void>();
+
+function setModality(next: InputModality) {
+	if (currentModality === next) return;
+	currentModality = next;
+	for (const listener of [...modalityListeners]) {
+		listener(next);
+	}
+}
+
 let forcedFocusTarget: HTMLElement | null = null;
 let forcedFocusModality: InputModality | null = null;
 
@@ -35,12 +50,12 @@ function ensureWindowListeners(win: Window | null | undefined) {
 	const onKeyDown = (event: KeyboardEvent) => {
 		lastInputEventTime = Date.now();
 		if (!isKeyboardModalityKey(event)) return;
-		currentModality = 'keyboard';
+		setModality('keyboard');
 	};
 
 	const onPointerDown = () => {
 		lastInputEventTime = Date.now();
-		currentModality = 'pointer';
+		setModality('pointer');
 	};
 
 	const onFocusIn = (event: FocusEvent) => {
@@ -51,7 +66,7 @@ function ensureWindowListeners(win: Window | null | undefined) {
 		if (Date.now() - lastInputEventTime <= RECENT_INPUT_WINDOW_MS) return;
 		// No recent keyboard/pointer input: this focus move came from an assistive technology
 		// (or a script), so focus rings must show again.
-		currentModality = 'virtual';
+		setModality('virtual');
 	};
 
 	win.addEventListener('keydown', onKeyDown, true);
@@ -103,12 +118,26 @@ export function trackInteractionModality(event?: Event, target?: HTMLElement | n
 
 	const inferred = inferModalityFromEvent(event);
 	if (inferred) {
-		currentModality = inferred;
+		setModality(inferred);
 	}
 }
 
 export function getInteractionModality(): InputModality {
 	return currentModality;
+}
+
+/**
+ * Calls `listener` whenever the interaction modality changes, and returns the unsubscribe
+ * function. Components use it to re-read `shouldShowFocusVisible` for an element that already
+ * holds focus: the browser re-evaluates `:focus-visible` on its own, and this is what lets a
+ * component notice.
+ */
+export function subscribeInputModality(listener: (modality: InputModality) => void): () => void {
+	initInputModality();
+	modalityListeners.add(listener);
+	return () => {
+		modalityListeners.delete(listener);
+	};
 }
 
 export function shouldShowFocusVisible(target: HTMLElement | null): boolean {
@@ -131,7 +160,7 @@ export function focusWithModality(
 	// If it is consumed later, currentModality still preserves the same modality as fallback.
 	forcedFocusTarget = target;
 	forcedFocusModality = modality;
-	currentModality = modality;
+	setModality(modality);
 
 	if (modality === 'pointer') {
 		const pointerFocusOptions = {

--- a/packages/ui/src/lib/switch/root/switch-root.svelte
+++ b/packages/ui/src/lib/switch/root/switch-root.svelte
@@ -5,6 +5,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import { setSwitchContext, type SwitchContext } from './context';
 
 	type SwitchRootProps = Omit<
@@ -136,6 +137,14 @@
 	let pressedKey: 'Enter' | 'Space' | null = $state(null);
 	let focused = $state(false);
 	let focusVisible = $state(false);
+
+	// The focus ring must appear when a pointer press is followed by a key press, and the
+	// modality alone changes there — no focus event fires to re-read it.
+	watchFocusVisible({
+		isFocused: () => focused,
+		element: () => rootRef,
+		set: (visible) => (focusVisible = visible)
+	});
 	let rootRef: HTMLSpanElement | null = $state(null);
 	let inputRef: HTMLInputElement | null = $state(null);
 

--- a/packages/ui/src/lib/switch/root/switch.test.ts
+++ b/packages/ui/src/lib/switch/root/switch.test.ts
@@ -308,4 +308,18 @@ describe('Switch.Root', () => {
 
 		expect(blurs).toBe(1);
 	});
+	// The modality can change while the element already holds focus, and no focus event fires
+	// there. React Aria and Base UI both bring the ring back on that key press.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		const screen = render(SwitchTest);
+		const element = screen
+			.getByRole('switch', { name: 'Enable notifications' })
+			.element() as HTMLElement;
+		element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+		element.focus();
+		await expect.poll(() => element.getAttribute('data-focused')).toBe('true');
+		expect(element.hasAttribute('data-focus-visible')).toBe(false);
+		await userEvent.keyboard('a');
+		await expect.poll(() => element.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/toggle/root/toggle-root.svelte
+++ b/packages/ui/src/lib/toggle/root/toggle-root.svelte
@@ -5,6 +5,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import {
 		getToggleGroupContext,
 		type ToggleGroupValue
@@ -91,6 +92,14 @@
 	let pressed = $state(false);
 	let focused = $state(false);
 	let focusVisible = $state(false);
+
+	// The focus ring must appear when a pointer press is followed by a key press, and the
+	// modality alone changes there — no focus event fires to re-read it.
+	watchFocusVisible({
+		isFocused: () => focused,
+		element: () => buttonRef,
+		set: (visible) => (focusVisible = visible)
+	});
 	let pressedKey: 'Enter' | 'Space' | null = $state(null);
 
 	untrack(() => {

--- a/packages/ui/src/lib/toggle/root/toggle.test.ts
+++ b/packages/ui/src/lib/toggle/root/toggle.test.ts
@@ -244,4 +244,16 @@ describe('Toggle.Root', () => {
 		expect(toggle.element()?.getAttribute('aria-pressed')).toBe('false');
 		expect(changes).toEqual([]);
 	});
+	// The modality can change while the element already holds focus, and no focus event fires
+	// there. React Aria and Base UI both bring the ring back on that key press.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		const screen = render(ToggleTest);
+		const element = screen.getByRole('button', { name: 'Favorite' }).element() as HTMLElement;
+		element.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true }));
+		element.focus();
+		await expect.poll(() => element.getAttribute('data-focused')).toBe('true');
+		expect(element.hasAttribute('data-focus-visible')).toBe(false);
+		await userEvent.keyboard('a');
+		await expect.poll(() => element.getAttribute('data-focus-visible')).toBe('true');
+	});
 });


### PR DESCRIPTION
## The bug

Click a control, then press a key. The focus ring stays off, for the rest of that focus. React Aria and Base UI both bring it back, and so does the `:focus-visible` of the browser.

Measured against the live React Aria CheckboxGroup example:

| | after the click | after the key |
| --- | --- | --- |
| React Aria `data-focus-visible` | absent | **`true`** |
| ours, before this change | absent | absent |

The browser was already right: after that key press, `element.matches(':focus-visible')` is `true` while our own attribute is absent.

## Why

`shouldShowFocusVisible` reads the interaction modality at the moment it is called. A component that calls it only from its focus handler keeps a snapshot: the pointer press seeds `false`, and the key press after it changes the modality with no focus event to make the component look again. Nothing could subscribe to a modality change, because there was no such API.

## The change

`primitives/input-modality.ts` routes every modality write through `setModality`, which notifies subscribers, and exports `subscribeInputModality`.

`primitives/focus-visible.svelte.ts` wraps it in `watchFocusVisible`, so an adopting component is three lines:

```svelte
watchFocusVisible({
	isFocused: () => focused,
	element: () => rootRef,
	set: (visible) => (focusVisible = visible)
});
```

## What is covered, and what is not

This part matters more than the diff, so it is exact.

**Fixed, and proven:** `Button`, `Checkbox`, `Switch`, `Toggle`. Each carries a regression test that fails with the subscription removed — checked one by one, not assumed.

**Inherits the fix:** everything that composes `Button.Root`, which includes the Accordion, DatePicker, DateRangePicker and TimePicker triggers.

**Needs nothing:** `Input`, `TextArea` and `Dropzone` pass the same probe unchanged. `Tabs`, `ComboBox` and `Autocomplete` refresh from a keydown handler that runs for every key, which does the same work by another road.

**Unmeasured, and untouched here:** the Table and Tree families, `ListBox.Item`, the DatePicker, DateRangePicker and TimePicker segments, `Calendar` body cells, the `Clock` wheel column and the NumberField input. All of them write focus-visible from a focus handler alone, which makes them candidates. None is confirmed: a probe has to be built for each fixture, and a careless one reports a healthy component as broken. That happened twice here, so the claim is left open rather than guessed.

## A note on how this was measured

The first count of this bug was 36 components. It was wrong. It came from clicking through the docs dev server after a branch switch, which left the browser asking for a module the other branch does not have: the dynamic import failed, the page never hydrated, and every component read as broken.

A probe on a composed component also proves nothing about that component — the Accordion and TimePicker triggers passed while the `Button.Root` inside them carried the fix.

Both are why the coverage above is stated as measurements rather than as a sweep.

## Verification

- `pnpm test` — 1751 tests, 134 files
- `pnpm test:ssr` — 27 tests
- `pnpm run lint` — prettier, eslint, TODO format, ASD-STE100
- `pnpm run typecheck` — 0 errors
