### PR TITLE
chore(docs): move the documentation tooling to @human-kit/markdown 0.3.1

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@fontsource-variable/geist": "^5.2.9",
 		"@fontsource-variable/roboto-serif": "^5.2.9",
-		"@human-kit/markdown": "^0.3.0",
+		"@human-kit/markdown": "^0.3.1",
 		"@human-kit/ui": "workspace:*",
 		"@lucide/svelte": "^0.574.0",
 		"@sveltejs/adapter-vercel": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: ^5.2.9
         version: 5.2.9
       '@human-kit/markdown':
-        specifier: ^0.3.0
-        version: 0.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        specifier: ^0.3.1
+        version: 0.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       '@human-kit/ui':
         specifier: workspace:*
         version: link:../packages/ui
@@ -532,8 +532,8 @@ packages:
   '@fontsource-variable/roboto-serif@5.2.9':
     resolution: {integrity: sha512-C502AILLgiRZmP3mgXXJiYp8/tQ+J/XQWw/dWtlRgE9X0yziBse9VHM9pCgaWqqzkdz4JB36fc0eYz0UritJIQ==}
 
-  '@human-kit/markdown@0.3.0':
-    resolution: {integrity: sha512-daHQ7tYMPytrMjIzTI2Z1lyR9lvRO/84+R04c0kRpORAX8TXySKxe0WQ1bZEAKKH6SWX5nRDst/vUxrtZBeSvA==}
+  '@human-kit/markdown@0.3.1':
+    resolution: {integrity: sha512-+rBrFW01tmhkIteA71yidABWDySc/lIL4ro4L95I0/wcESs4p5GQtB8bNoi1/RUY5XUNm/zIST5AZIVVCKzqTw==}
     hasBin: true
     peerDependencies:
       svelte: ^5.0.0
@@ -3213,7 +3213,7 @@ snapshots:
 
   '@fontsource-variable/roboto-serif@5.2.9': {}
 
-  '@human-kit/markdown@0.3.0(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@human-kit/markdown@0.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       property-information: 7.2.0
       remark-gfm: 4.0.1


### PR DESCRIPTION
## Why

`@human-kit/markdown@0.3.0` gave a part with no declaration in the shared `types.ts` of its group the props of the first declaration in that file. `CheckboxGroup.Item` and `ToggleGroup.Item` thus showed the props of their `Root`.

The api.json files in the repository are correct, because #87 and #90 wrote them with the corrected tool. But the next `pnpm docs:api` made them wrong again. Version 0.3.1 (Agustin-Delgado/humandocs#12) reads each part from its own file.

## What this changes

- `docs` depends on `^0.3.1`.
- The lockfile holds the new version.

## How this was verified

`pnpm docs:api` writes the same files that the repository holds. The command leaves no difference.

No library source changes, thus no changeset.
