### PR TITLE
fix(a11y): follow the modality on the rest of the components that hold focus

### DIFF
--- a/.changeset/focus-visible-sweep.md
+++ b/.changeset/focus-visible-sweep.md
@@ -1,0 +1,5 @@
+---
+'@human-kit/ui': patch
+---
+
+Bring the focus ring back on `RadioGroup.Item`, `Table` and `Calendar.BodyCell` when a key press follows a pointer press. These read the interaction modality only when they take focus, thus the ring stayed off for the rest of that focus. They now follow the modality for as long as they hold focus, the same as `Button`, `Checkbox`, `Switch` and `Toggle`. `Table` keeps one focus-visible value for every part, thus the watch is on the table and it serves the cell, the row and the header cell together.

--- a/packages/ui/src/lib/calendar/body-cell/calendar-body-cell.svelte
+++ b/packages/ui/src/lib/calendar/body-cell/calendar-body-cell.svelte
@@ -58,6 +58,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 
 	type CalendarBodyCellProps = Omit<HTMLAttributes<HTMLTableCellElement>, 'children'> & {
 		date: string;
@@ -153,6 +154,12 @@
 		calendar.setFocusedValue(date);
 		calendar.setFocusVisible(shouldShowFocusVisible(buttonElement ?? null));
 	}
+
+	watchFocusVisible({
+		isFocused: () => hasDomFocus,
+		element: () => buttonElement ?? null,
+		set: (visible) => calendar.setFocusVisible(visible)
+	});
 
 	function handleBlur() {
 		hasDomFocus = false;

--- a/packages/ui/src/lib/calendar/body-cell/calendar-body-cell.test.ts
+++ b/packages/ui/src/lib/calendar/body-cell/calendar-body-cell.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
 import CalendarRootTest from '../root/calendar-root-test.svelte';
 import { formatCalendarDate, getTodayUtcDate } from '../root/date-utils';
 
@@ -181,5 +182,20 @@ describe('Calendar.BodyCell', () => {
 			document.querySelector('[role="button"][data-date="2026-02-08"][data-range-end]')
 		).toBeFalsy();
 		expect(document.querySelector('[data-range-end]')).toBeFalsy();
+	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(CalendarRootTest);
+		const cell = document.querySelector<HTMLElement>('[role="gridcell"][data-date]')!;
+
+		await userEvent.click(cell);
+		await expect.poll(() => cell.getAttribute('data-focused')).toBe('true');
+		expect(cell.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => cell.getAttribute('data-focus-visible')).toBe('true');
 	});
 });

--- a/packages/ui/src/lib/clock/wheel-column/clock-wheel-column.test.ts
+++ b/packages/ui/src/lib/clock/wheel-column/clock-wheel-column.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
 import ClockRootTest from './clock-wheel-column-test.svelte';
 import ClockWheelColumnBindableTest from './clock-wheel-column-bindable-test.svelte';
 import ClockWheelColumnCustomSnippetTest from './clock-wheel-column-custom-snippet-test.svelte';
@@ -164,5 +165,20 @@ describe('Clock.WheelColumn', () => {
 		await expect
 			.poll(() => document.querySelector('[data-testid="clock-value"]')?.textContent)
 			.toBe('15:30');
+	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(ClockRootTest);
+		const column = getClockColumns()[0]!;
+
+		await userEvent.click(column);
+		await expect.poll(() => document.activeElement).toBe(column);
+		expect(column.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => column.getAttribute('data-focus-visible')).toBe('true');
 	});
 });

--- a/packages/ui/src/lib/combobox/root/combobox.test.ts
+++ b/packages/ui/src/lib/combobox/root/combobox.test.ts
@@ -1724,4 +1724,20 @@ describe('ComboBox', () => {
 			expect(input.element().getAttribute('aria-activedescendant')).toBe(activeDescendant);
 		});
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		const screen = render(ComboBoxTest);
+		const input = screen.getByRole('combobox');
+		const wrapper = document.querySelector<HTMLElement>('[data-combobox]')!;
+
+		await input.click();
+		await expect.poll(() => wrapper.getAttribute('data-focused')).toBe('true');
+		expect(wrapper.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => wrapper.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/datepicker/segment/date-picker-segment.test.ts
+++ b/packages/ui/src/lib/datepicker/segment/date-picker-segment.test.ts
@@ -635,4 +635,19 @@ describe('DatePicker.Segment', () => {
 		expect(wasNotCanceled).toBe(false);
 		expect(daySegment.element()?.getAttribute('data-placeholder')).toBe('true');
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(DatePickerTest);
+		const segment = getSegment('day').element();
+
+		await userEvent.click(segment);
+		await expect.poll(() => segment.getAttribute('data-focused')).toBe('true');
+		expect(segment.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => segment.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/listbox/item/listbox-item.test.ts
+++ b/packages/ui/src/lib/listbox/item/listbox-item.test.ts
@@ -416,4 +416,19 @@ describe('ListBox.Item', () => {
 			expect(options[3].hasAttribute('data-focused')).toBe(true);
 		});
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(ListBoxTest);
+		const option = document.querySelector<HTMLElement>('[role="option"]')!;
+
+		await userEvent.click(option);
+		await expect.poll(() => option.getAttribute('data-focused')).toBe('true');
+		expect(option.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => option.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/numberfield/number-field.test.ts
+++ b/packages/ui/src/lib/numberfield/number-field.test.ts
@@ -925,4 +925,21 @@ describe('NumberField', () => {
 			document.querySelectorAll('[data-focus-visible="true"]:not([data-number-field-input="true"])')
 		).toHaveLength(0);
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		const screen = render(NumberFieldTest);
+		const inputElement = screen
+			.getByRole('spinbutton', { name: 'Amount' })
+			.element() as HTMLInputElement;
+
+		await userEvent.click(inputElement);
+		await expect.poll(() => inputElement.getAttribute('data-focused')).toBe('true');
+		expect(inputElement.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => inputElement.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/radio-group/TODO.md
+++ b/packages/ui/src/lib/radio-group/TODO.md
@@ -19,5 +19,5 @@ Track RadioGroup work with a single mandatory TODO format.
 - [ ] [S][P1][Area: API][Owner: Unassigned][Target: TBD] Add a `RadioGroup.Label` part, so the group names itself without `aria-labelledby` by hand.
 - [ ] [S][P1][Area: API][Owner: Unassigned][Target: TBD] Add an optional `nativeButton` rendering mode to `RadioGroup.Item`, for sibling-label patterns.
 - [ ] [C][P2][Area: Animation][Owner: Unassigned][Target: TBD] Add indicator presence data for enter and exit animations.
-- [ ] [S][P1][Area: Accessibility][Owner: Unassigned][Target: TBD] Adopt `watchFocusVisible` once it lands, so a key press after a pointer press brings the ring back.
+- [x] [S][P1][Area: Accessibility][Owner: Unassigned][Target: Done] Adopt `watchFocusVisible`, so a key press after a pointer press brings the ring back.
 - [ ] [C][P2][Area: Forms][Owner: Unassigned][Target: TBD] Report the required state through constraint validation with `aria-describedby`.

--- a/packages/ui/src/lib/radio-group/item/radio-group-item.svelte
+++ b/packages/ui/src/lib/radio-group/item/radio-group-item.svelte
@@ -5,6 +5,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import { useRadioGroupContext } from '../root/context.svelte';
 	import { setRadioGroupItemContext, type RadioGroupItemContext } from './context';
 
@@ -141,6 +142,12 @@
 	const focused = $derived(radioGroup.isFocused(value));
 	const focusVisible = $derived(radioGroup.isFocusVisible(value));
 	const tabIndex = $derived(radioGroup.getTabIndex(value));
+
+	watchFocusVisible({
+		isFocused: () => focused,
+		element: () => rootRef,
+		set: (visible) => radioGroup.setFocusVisible(visible)
+	});
 
 	$effect(() => {
 		if (!renderedDisabled && !renderedReadOnly) return;

--- a/packages/ui/src/lib/radio-group/root/radio-group.test.ts
+++ b/packages/ui/src/lib/radio-group/root/radio-group.test.ts
@@ -293,6 +293,22 @@ describe('RadioGroup.Root', () => {
 		expectNoFalseFocusAttributes(document);
 	});
 
+	// The modality can change while the radio already holds focus, and no focus event fires
+	// to report it. A key that the radio ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(RadioGroupTest);
+
+		const medium = getRadio('radio-medium');
+		await userEvent.click(medium);
+		expect(medium.getAttribute('data-focused')).toBe('true');
+		expect(medium.hasAttribute('data-focus-visible')).toBe(false);
+
+		await userEvent.keyboard('a');
+		await expect.poll(() => medium.getAttribute('data-focus-visible')).toBe('true');
+		expectFocusVisibleImpliesFocused(medium);
+	});
+
 	it('gives every radio the name of the group, and submits the selected value', async () => {
 		const submissions: (string | null)[] = [];
 		render(RadioGroupFormTest, {

--- a/packages/ui/src/lib/table/cell/table-cell.test.ts
+++ b/packages/ui/src/lib/table/cell/table-cell.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
 import TableTest from '../root/table-test.svelte';
 
 describe('Table.Cell', () => {
@@ -8,5 +9,20 @@ describe('Table.Cell', () => {
 		expect(document.querySelector('tbody [role="rowheader"]')?.textContent).toContain(
 			'danilo@example.com'
 		);
+	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(TableTest);
+		const cell = document.querySelector<HTMLElement>('tbody [role="rowheader"]')!;
+
+		await userEvent.click(cell);
+		await expect.poll(() => cell.getAttribute('data-focused')).toBe('true');
+		expect(cell.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => cell.getAttribute('data-focus-visible')).toBe('true');
 	});
 });

--- a/packages/ui/src/lib/table/column-header-cell/table-column-header-cell.svelte
+++ b/packages/ui/src/lib/table/column-header-cell/table-column-header-cell.svelte
@@ -11,6 +11,8 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import { isRtl } from '../../internal/rtl';
 
 	let { children, class: className = '', ...restProps }: TableColumnHeaderCellProps = $props();
@@ -173,6 +175,28 @@
 		isFocusWithin = false;
 		isFocusVisibleWithin = false;
 	}
+
+	function getFocusedDescendant() {
+		if (!element) return null;
+		const active = element.ownerDocument.activeElement;
+		if (!(active instanceof HTMLElement) || active === element) return null;
+		return element.contains(active) ? active : null;
+	}
+
+	watchFocusVisible({
+		isFocused: () => isElementFocused,
+		element: () => element ?? null,
+		set: (visible) => {
+			isElementFocusVisible = visible;
+			table.setFocusVisible(visible);
+		}
+	});
+
+	watchFocusVisible({
+		isFocused: () => isFocusWithin,
+		element: getFocusedDescendant,
+		set: (visible) => (isFocusVisibleWithin = visible)
+	});
 
 	function handleClick() {
 		// A drag-resize that just ended emits a residual click on the header;

--- a/packages/ui/src/lib/table/column-header-cell/table-column-header-cell.test.ts
+++ b/packages/ui/src/lib/table/column-header-cell/table-column-header-cell.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { render } from 'vitest-browser-svelte';
+import { userEvent } from 'vitest/browser';
 import TableTest from '../root/table-test.svelte';
 
 describe('Table.ColumnHeaderCell', () => {
@@ -7,5 +8,20 @@ describe('Table.ColumnHeaderCell', () => {
 		render(TableTest);
 		const headers = document.querySelectorAll<HTMLElement>('thead [role="columnheader"]');
 		await expect.poll(() => headers[1]?.getAttribute('data-sortable')).toBe('true');
+	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(TableTest);
+		const header = document.querySelectorAll<HTMLElement>('thead [role="columnheader"]')[0]!;
+
+		await userEvent.click(header);
+		await expect.poll(() => header.getAttribute('data-focused')).toBe('true');
+		expect(header.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => header.getAttribute('data-focus-visible')).toBe('true');
 	});
 });

--- a/packages/ui/src/lib/table/column-resizer/table-column-resizer.test.ts
+++ b/packages/ui/src/lib/table/column-resizer/table-column-resizer.test.ts
@@ -1746,4 +1746,22 @@ describe('Table.ColumnResizer', () => {
 		await expect.poll(() => document.activeElement).toBe(emailHeaderCell);
 		await expect.element(emailResizer).not.toHaveAttribute('data-resizing');
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(ColumnResizerTest);
+		const emailResizer = document.querySelector<HTMLElement>('[data-testid="email-resizer"]')!;
+
+		emailResizer.dispatchEvent(
+			new PointerEvent('pointerdown', { bubbles: true, isPrimary: true, pointerType: 'mouse' })
+		);
+		emailResizer.focus();
+		await expect.poll(() => emailResizer.getAttribute('data-focused')).toBe('true');
+		expect(emailResizer.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => emailResizer.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/table/root/table-root.svelte
+++ b/packages/ui/src/lib/table/root/table-root.svelte
@@ -21,6 +21,7 @@
 		shouldShowFocusVisible,
 		trackInteractionModality
 	} from '../../primitives/input-modality';
+	import { watchFocusVisible } from '../../primitives/focus-visible.svelte';
 	import { visuallyHiddenStyle } from '../utils/visually-hidden-style';
 	import type { TableRootProps } from '../types.js';
 	import {
@@ -499,15 +500,37 @@
 		focusWithin =
 			!!tableElement && !!document.activeElement && tableElement.contains(document.activeElement);
 		if (!focusWithin) {
-			focusVisible = false;
+			setFocusVisible(false);
 			ctx.setFocusedCell(null);
 		}
 	}
 
 	function handleFocusIn(event: FocusEvent) {
 		focusWithin = true;
-		focusVisible = shouldShowFocusVisible(event.target as HTMLElement | null);
+		setFocusVisible(shouldShowFocusVisible(event.target as HTMLElement | null));
 	}
+
+	// Every part of the table reads one focus-visible value, and each writes it from its own
+	// focus handler. One watch on the focused descendant therefore serves them all: a key press
+	// that follows a pointer press brings the ring back on the cell, the row and the checkbox
+	// at once.
+	function getFocusedDescendant() {
+		if (!tableElement) return null;
+		const active = tableElement.ownerDocument.activeElement;
+		if (!(active instanceof HTMLElement)) return null;
+		return tableElement.contains(active) ? active : null;
+	}
+
+	function setFocusVisible(visible: boolean) {
+		focusVisible = visible;
+		ctx.setFocusVisible(visible);
+	}
+
+	watchFocusVisible({
+		isFocused: () => focusWithin,
+		element: getFocusedDescendant,
+		set: setFocusVisible
+	});
 
 	function handleFocusOut() {
 		queueMicrotask(syncFocusWithin);
@@ -515,14 +538,14 @@
 
 	function handleMouseDown(event: MouseEvent) {
 		trackInteractionModality(event, event.target as HTMLElement | null);
-		focusVisible = false;
+		setFocusVisible(false);
 	}
 
+	// No focus-visible write here: `trackInteractionModality` reports the key to the modality,
+	// and the watch above answers. A key that carries a modifier is not a modality change, and
+	// must leave the ring as the pointer left it.
 	function handleKeyDown(event: KeyboardEvent) {
 		trackInteractionModality(event, event.target as HTMLElement | null);
-		if (focusWithin) {
-			focusVisible = true;
-		}
 	}
 </script>
 

--- a/packages/ui/src/lib/timepicker/segment/time-picker-segment.test.ts
+++ b/packages/ui/src/lib/timepicker/segment/time-picker-segment.test.ts
@@ -337,4 +337,19 @@ describe('TimePicker.Segment', () => {
 		expect(wasNotCanceled).toBe(true);
 		expect(dayPeriodSegment.element()?.textContent).toBe(initialText);
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(TimePickerTest);
+		const segment = getSegment('hour').element();
+
+		await userEvent.click(segment);
+		await expect.poll(() => segment.getAttribute('data-focused')).toBe('true');
+		expect(segment.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => segment.getAttribute('data-focus-visible')).toBe('true');
+	});
 });

--- a/packages/ui/src/lib/tree/item/tree-item.test.ts
+++ b/packages/ui/src/lib/tree/item/tree-item.test.ts
@@ -150,4 +150,19 @@ describe('Tree.Item', () => {
 		await expect.element(reports).toHaveAttribute('data-focused', 'true');
 		expect(documents.getAttribute('data-focused')).toBeNull();
 	});
+
+	// The modality can change while the element already holds focus, and no focus event fires
+	// to report it. A key that the component ignores must bring the ring back, the same as in
+	// React Aria and Base UI.
+	it('shows the focus ring when a key press follows a pointer press', async () => {
+		render(TreeItemTest);
+		const item = document.querySelector<HTMLElement>('[role="treeitem"]')!;
+
+		await userEvent.click(item);
+		await expect.poll(() => item.getAttribute('data-focused')).toBe('true');
+		expect(item.getAttribute('data-focus-visible')).toBeNull();
+
+		await userEvent.keyboard('{F9}');
+		await expect.poll(() => item.getAttribute('data-focus-visible')).toBe('true');
+	});
 });


### PR DESCRIPTION
## Why

#88 fixed `Button`, `Checkbox`, `Switch` and `Toggle`: they read the interaction modality only when they take focus, thus a key press after a pointer press left the ring off while the browser had already flipped `:focus-visible` back on. That PR listed the components that were not measured. This measures them.

## How each one was measured

One probe per component: a pointer press to take focus, then `{F9}` — a key that no component acts on. The ring must come back.

Four were wrong, and each probe fails without its change:

| Component | What holds the value |
|---|---|
| `RadioGroup.Item` | the group |
| `Table.Cell` (and the row) | one value on the table |
| `Table.ColumnHeaderCell` | two of its own: its element, and its descendants |
| `Calendar.BodyCell` | the calendar |

`Table` keeps one focus-visible value for every part, thus one watch on the table serves the cell, the row and the checkbox together.

Seven probes pass with no change, because these components recompute the ring in their own keydown handlers. They stay as regression tests: `ListBox.Item`, `Tree.Item`, `NumberField`, `Clock.WheelColumn`, `ComboBox`, `DatePicker.Segment` and `TimePicker.Segment`.

## Also in here

`Table.Root` and `Table.ColumnHeaderCell` no longer write the ring from their keydown handlers. The watch answers the modality, thus a key that carries a modifier (`Ctrl+Home`, say) now leaves the ring as the pointer left it, which is what React Aria does.

## What this does not cover

The pickers give `data-focused` and `data-focus-visible` to `Button.Root` as props, but `Button.Root` spreads `restProps` before its own attributes, thus its own values win and the props are dead. The ring on those triggers is correct because #88 fixed `Button`. The same holds for `Accordion.Trigger`. A probe on any of them measures `Button`, thus none is included here.

## Verification

`pnpm test` — 1806 tests pass. `pnpm run check` — 959 files, no errors. `pnpm run lint` passes.