### PR TITLE
feat(groups): add CheckboxGroup.Label and RadioGroup.Label

### DIFF
--- a/.changeset/group-label-part.md
+++ b/.changeset/group-label-part.md
@@ -1,0 +1,5 @@
+---
+'@human-kit/ui': minor
+---
+
+Add `CheckboxGroup.Label` and `RadioGroup.Label`. The part names its group: it registers its id with the root, which gives it to the group element as `aria-labelledby`. Two labels read as one name, in the order they appear, and an `aria-labelledby` that the caller gives stands. It renders a `<span>` and not a `<label>`, because a `<label>` names one control and cannot name a set. This also corrects the API reference of `RadioGroup.Item`, which listed the props of `RadioGroup.Root`.

--- a/docs/package.json
+++ b/docs/package.json
@@ -14,7 +14,7 @@
 	"dependencies": {
 		"@fontsource-variable/geist": "^5.2.9",
 		"@fontsource-variable/roboto-serif": "^5.2.9",
-		"@human-kit/markdown": "^0.3.1",
+		"@human-kit/markdown": "^0.3.2",
 		"@human-kit/ui": "workspace:*",
 		"@lucide/svelte": "^0.574.0",
 		"@sveltejs/adapter-vercel": "^6.3.1",

--- a/docs/src/content/checkbox-group/api.json
+++ b/docs/src/content/checkbox-group/api.json
@@ -121,6 +121,39 @@
 			]
 		},
 		{
+			"name": "Label",
+			"description": "The accessible name of the group. It gives its id to the group as `aria-labelledby`.",
+			"props": [
+				{
+					"name": "children",
+					"type": "Snippet",
+					"required": false,
+					"default": null,
+					"description": "The name of the group."
+				},
+				{
+					"name": "class",
+					"type": "string",
+					"required": false,
+					"default": "''",
+					"description": ""
+				},
+				{
+					"name": "id",
+					"type": "string",
+					"required": false,
+					"default": null,
+					"description": "The id of the label element. The component makes one when you give none."
+				}
+			],
+			"dataAttributes": [
+				{
+					"name": "data-checkbox-group-label",
+					"description": "Present on the label of the group."
+				}
+			]
+		},
+		{
 			"name": "Item",
 			"description": "One box of the group. It is Checkbox.Root under the namespace of the group, and the two names are the same component.",
 			"props": [

--- a/docs/src/content/checkbox-group/index.md
+++ b/docs/src/content/checkbox-group/index.md
@@ -20,12 +20,15 @@ description: A group of checkboxes with one array value, a shared name for the f
 
 `CheckboxGroup.Root` contains `CheckboxGroup.Item` boxes. That part is `Checkbox.Root` under the namespace of the group, and the two names are the same component. Each box must have a unique `value`. The group holds the checked state of each box.
 
+`CheckboxGroup.Label` names the group. It is optional: `aria-label` on the root does the same for a name that the user does not see.
+
 ```svelte
 <script>
 	import { CheckboxGroup } from '@human-kit/ui';
 </script>
 
-<CheckboxGroup.Root name="colors" defaultValue={['red']} aria-label="Colors">
+<CheckboxGroup.Root name="colors" defaultValue={['red']}>
+	<CheckboxGroup.Label>Colors</CheckboxGroup.Label>
 	<CheckboxGroup.Item value="red">
 		<CheckboxGroup.Indicator>x</CheckboxGroup.Indicator>
 	</CheckboxGroup.Item>
@@ -86,7 +89,8 @@ Keep the parent checkbox out of the group. In the group, it becomes one more val
 ## Accessibility
 
 - `CheckboxGroup.Root` has `role="group"`.
-- Give the group an accessible name with `aria-label` or `aria-labelledby`.
+- Give the group an accessible name with `CheckboxGroup.Label`, or with `aria-label` on the root. The label writes `aria-labelledby` on the group. An `aria-labelledby` that you give stands, thus your own element wins.
+- `CheckboxGroup.Label` renders a `<span>`, and not a `<label>`. A `<label>` names one control, thus it cannot name a set.
 - Each box keeps its own tab stop. The `Space` key changes the box that has the focus.
 - `required` marks no element with `aria-required`: `role="group"` does not support that
   property. Put the word in the group label, and give the reason with `aria-describedby`.

--- a/docs/src/content/radio-group/api.json
+++ b/docs/src/content/radio-group/api.json
@@ -106,16 +106,16 @@
 			],
 			"dataAttributes": [
 				{
-					"name": "data-radio-group-root",
-					"description": "Identifies the group element."
-				},
-				{
 					"name": "data-disabled",
 					"description": "Present when the whole group is disabled."
 				},
 				{
 					"name": "data-orientation",
 					"description": "The group orientation (\"horizontal\" or \"vertical\")."
+				},
+				{
+					"name": "data-radio-group-root",
+					"description": "Identifies the group element."
 				},
 				{
 					"name": "data-readonly",
@@ -128,78 +128,15 @@
 			]
 		},
 		{
-			"name": "Item",
-			"description": "One answer of the group. It makes a span with role=\"radio\" and a hidden radio input for the form.",
+			"name": "Label",
+			"description": "The accessible name of the group. It gives its id to the group as `aria-labelledby`.",
 			"props": [
-				{
-					"name": "value",
-					"type": "RadioGroupValue | null",
-					"required": false,
-					"default": null,
-					"description": "The selected value. When you give this prop, it is the source of truth, with `bind:value` or\nwithout it. The component writes each change here and reports it through `onChange`.\n\nWithout a binding, that write stays local. Thus a parent that hears `onChange` and refuses the\nchange — it sends no new `value` down — sees the group move. The group then goes back to the\nvalue of the parent at the next render."
-				},
-				{
-					"name": "defaultValue",
-					"type": "RadioGroupValue | null",
-					"required": false,
-					"default": null,
-					"description": "The selected value at the start, for when you give no `value`."
-				},
-				{
-					"name": "onChange",
-					"type": "(value: RadioGroupValue) => void",
-					"required": false,
-					"default": null,
-					"description": "The component calls it when the user selects a radio."
-				},
-				{
-					"name": "name",
-					"type": "string",
-					"required": false,
-					"default": null,
-					"description": "The `name` of the hidden input of every radio in the group, for form submission."
-				},
-				{
-					"name": "form",
-					"type": "string",
-					"required": false,
-					"default": null,
-					"description": "The id of the form of the hidden inputs."
-				},
-				{
-					"name": "disabled",
-					"type": "boolean",
-					"required": false,
-					"default": "false",
-					"description": "Disables each radio in the group."
-				},
-				{
-					"name": "readonly",
-					"type": "boolean",
-					"required": false,
-					"default": null,
-					"description": "Shows the value of the group, and refuses each change from the user."
-				},
-				{
-					"name": "required",
-					"type": "boolean",
-					"required": false,
-					"default": null,
-					"description": "Marks the group with `aria-required`, and marks each hidden input as required."
-				},
-				{
-					"name": "orientation",
-					"type": "RadioGroupOrientation",
-					"required": false,
-					"default": null,
-					"description": "The orientation of the layout. It sets `aria-orientation` and `data-orientation`, and it\nchooses the arrow keys that move the focus."
-				},
 				{
 					"name": "children",
 					"type": "Snippet",
 					"required": false,
 					"default": null,
-					"description": "The radios of the group."
+					"description": "The name of the group."
 				},
 				{
 					"name": "class",
@@ -213,43 +150,105 @@
 					"type": "string",
 					"required": false,
 					"default": null,
-					"description": "The id of the group element. The component makes one when you give none."
-				},
-				{
-					"name": "element",
-					"type": "HTMLDivElement | null",
-					"required": false,
-					"default": null,
-					"description": "The group element. Use `bind:element` to read it."
-				},
-				{
-					"name": "context",
-					"type": "RadioGroupContext",
-					"required": false,
-					"default": null,
-					"description": "The state of the group. Use `bind:context` to read the selection from outside."
+					"description": "The id of the label element. The component makes one when you give none."
 				}
 			],
 			"dataAttributes": [
 				{
-					"name": "data-radio-group-item",
-					"description": "Identifies the radio element."
+					"name": "data-radio-group-label",
+					"description": "Present on the label of the group."
+				}
+			]
+		},
+		{
+			"name": "Item",
+			"description": "One answer of the group. It makes a span with role=\"radio\" and a hidden radio input for the form.",
+			"props": [
+				{
+					"name": "id",
+					"type": "string",
+					"required": false,
+					"default": null,
+					"description": "The id of the hidden input. A `<label for>` points to it."
 				},
+				{
+					"name": "element",
+					"type": "HTMLSpanElement | null",
+					"required": false,
+					"default": null,
+					"description": "The radio element. Use `bind:element` to read it."
+				},
+				{
+					"name": "value",
+					"type": "string",
+					"required": true,
+					"default": null,
+					"description": "The value this radio writes to the group. It must be unique inside the group."
+				},
+				{
+					"name": "disabled",
+					"type": "boolean",
+					"required": false,
+					"default": "false",
+					"description": "Disables this radio alone. The group can disable every radio at once."
+				},
+				{
+					"name": "children",
+					"type": "Snippet",
+					"required": false,
+					"default": null,
+					"description": "The indicator and the content of the radio."
+				},
+				{
+					"name": "class",
+					"type": "string",
+					"required": false,
+					"default": "''",
+					"description": ""
+				},
+				{
+					"name": "aria-label",
+					"type": "string",
+					"required": false,
+					"default": null,
+					"description": "The accessible name, for a radio with no text of its own."
+				},
+				{
+					"name": "aria-labelledby",
+					"type": "string",
+					"required": false,
+					"default": null,
+					"description": "The id of the element that names this radio."
+				}
+			],
+			"dataAttributes": [
 				{
 					"name": "data-checked",
 					"description": "Present when the radio is checked."
 				},
 				{
-					"name": "data-unchecked",
-					"description": "Present when the radio is not checked."
+					"name": "data-disabled",
+					"description": "Present when the radio or its group is disabled."
+				},
+				{
+					"name": "data-focus-visible",
+					"description": "Present when the focus came from the keyboard."
+				},
+				{
+					"name": "data-focused",
+					"description": "Present when the radio has the focus."
 				},
 				{
 					"name": "data-pressed",
 					"description": "Present while the radio is held down."
 				},
 				{
-					"name": "data-disabled",
-					"description": "Present when the radio or its group is disabled."
+					"name": "data-radio-group-input",
+					"description": ""
+				},
+				{
+					"name": "data-radio-group-item",
+					"description": "Identifies the radio element."
 				},
 				{
 					"name": "data-readonly",
@@ -260,12 +259,8 @@
 					"description": "Present when the group is required."
 				},
 				{
-					"name": "data-focused",
-					"description": "Present when the radio has the focus."
-				},
-				{
-					"name": "data-focus-visible",
-					"description": "Present when the focus came from the keyboard."
+					"name": "data-unchecked",
+					"description": "Present when the radio is not checked."
 				}
 			]
 		},
@@ -274,74 +269,18 @@
 			"description": "The mark of a checked radio. It is in the DOM only while the radio is checked, unless you give forceMount.",
 			"props": [
 				{
-					"name": "value",
-					"type": "RadioGroupValue | null",
-					"required": false,
-					"default": null,
-					"description": "The selected value. When you give this prop, it is the source of truth, with `bind:value` or\nwithout it. The component writes each change here and reports it through `onChange`.\n\nWithout a binding, that write stays local. Thus a parent that hears `onChange` and refuses the\nchange — it sends no new `value` down — sees the group move. The group then goes back to the\nvalue of the parent at the next render."
-				},
-				{
-					"name": "defaultValue",
-					"type": "RadioGroupValue | null",
-					"required": false,
-					"default": null,
-					"description": "The selected value at the start, for when you give no `value`."
-				},
-				{
-					"name": "onChange",
-					"type": "(value: RadioGroupValue) => void",
-					"required": false,
-					"default": null,
-					"description": "The component calls it when the user selects a radio."
-				},
-				{
-					"name": "name",
-					"type": "string",
-					"required": false,
-					"default": null,
-					"description": "The `name` of the hidden input of every radio in the group, for form submission."
-				},
-				{
-					"name": "form",
-					"type": "string",
-					"required": false,
-					"default": null,
-					"description": "The id of the form of the hidden inputs."
-				},
-				{
-					"name": "disabled",
+					"name": "forceMount",
 					"type": "boolean",
 					"required": false,
-					"default": null,
-					"description": "Disables each radio in the group."
-				},
-				{
-					"name": "readonly",
-					"type": "boolean",
-					"required": false,
-					"default": null,
-					"description": "Shows the value of the group, and refuses each change from the user."
-				},
-				{
-					"name": "required",
-					"type": "boolean",
-					"required": false,
-					"default": null,
-					"description": "Marks the group with `aria-required`, and marks each hidden input as required."
-				},
-				{
-					"name": "orientation",
-					"type": "RadioGroupOrientation",
-					"required": false,
-					"default": null,
-					"description": "The orientation of the layout. It sets `aria-orientation` and `data-orientation`, and it\nchooses the arrow keys that move the focus."
+					"default": "false",
+					"description": "Keeps the indicator in the DOM while the radio is not checked, for exit animations."
 				},
 				{
 					"name": "children",
 					"type": "Snippet",
 					"required": false,
 					"default": null,
-					"description": "The radios of the group."
+					"description": "The mark itself."
 				},
 				{
 					"name": "class",
@@ -349,49 +288,32 @@
 					"required": false,
 					"default": "''",
 					"description": ""
-				},
-				{
-					"name": "id",
-					"type": "string",
-					"required": false,
-					"default": null,
-					"description": "The id of the group element. The component makes one when you give none."
-				},
-				{
-					"name": "element",
-					"type": "HTMLDivElement | null",
-					"required": false,
-					"default": null,
-					"description": "The group element. Use `bind:element` to read it."
-				},
-				{
-					"name": "context",
-					"type": "RadioGroupContext",
-					"required": false,
-					"default": null,
-					"description": "The state of the group. Use `bind:context` to read the selection from outside."
 				}
 			],
 			"dataAttributes": [
-				{
-					"name": "data-radio-group-indicator",
-					"description": "Identifies the indicator element."
-				},
 				{
 					"name": "data-checked",
 					"description": "Present when the radio is checked."
 				},
 				{
-					"name": "data-unchecked",
-					"description": "Present when the radio is not checked."
+					"name": "data-disabled",
+					"description": "Present when the radio or its group is disabled."
+				},
+				{
+					"name": "data-focus-visible",
+					"description": "Present when the focus came from the keyboard."
+				},
+				{
+					"name": "data-focused",
+					"description": "Present when the radio has the focus."
 				},
 				{
 					"name": "data-pressed",
 					"description": "Present while the radio is held down."
 				},
 				{
-					"name": "data-disabled",
-					"description": "Present when the radio or its group is disabled."
+					"name": "data-radio-group-indicator",
+					"description": "Identifies the indicator element."
 				},
 				{
 					"name": "data-readonly",
@@ -402,12 +324,8 @@
 					"description": "Present when the group is required."
 				},
 				{
-					"name": "data-focused",
-					"description": "Present when the radio has the focus."
-				},
-				{
-					"name": "data-focus-visible",
-					"description": "Present when the focus came from the keyboard."
+					"name": "data-unchecked",
+					"description": "Present when the radio is not checked."
 				}
 			]
 		}

--- a/docs/src/content/radio-group/demos/hero.svelte
+++ b/docs/src/content/radio-group/demos/hero.svelte
@@ -15,14 +15,16 @@
 	const dotClass =
 		'touch-target inline-flex size-4 shrink-0 items-center justify-center rounded-full border border-neutral-300 bg-white outline-none transition-colors data-[checked=true]:border-neutral-900 data-[focus-visible=true]:outline-solid data-[focus-visible=true]:outline-2 data-[focus-visible=true]:outline-offset-2 data-[focus-visible=true]:outline-neutral-900 dark:border-neutral-700 dark:bg-neutral-900 dark:data-[checked=true]:border-white dark:data-[focus-visible=true]:outline-white';
 	const labelClass = 'cursor-pointer text-sm text-neutral-900 select-none dark:text-white';
+	const groupLabelClass = 'text-sm font-medium text-neutral-900 dark:text-white';
 </script>
 
 <RadioGroup.Root
 	bind:value
 	name="size"
-	aria-label="Size"
 	class="flex flex-col gap-2 data-[orientation=horizontal]:flex-row"
 >
+	<RadioGroup.Label class={groupLabelClass}>Size</RadioGroup.Label>
+
 	{#each sizes as size (size.value)}
 		<div class="flex items-center gap-2">
 			<RadioGroup.Item id="size-{size.value}" value={size.value} class={dotClass}>

--- a/docs/src/content/radio-group/index.md
+++ b/docs/src/content/radio-group/index.md
@@ -20,12 +20,15 @@ description: A group of radio buttons with one value, a shared name for the form
 
 `RadioGroup.Root` contains `RadioGroup.Item` buttons. Each button must have a unique `value`, and it must be in a group. A radio on its own has no state, and no way to unselect itself.
 
+`RadioGroup.Label` names the group. It is optional: `aria-label` on the root does the same for a name that the user does not see.
+
 ```svelte
 <script>
 	import { RadioGroup } from '@human-kit/ui';
 </script>
 
-<RadioGroup.Root name="size" defaultValue="medium" aria-label="Size">
+<RadioGroup.Root name="size" defaultValue="medium">
+	<RadioGroup.Label>Size</RadioGroup.Label>
 	<RadioGroup.Item value="small">
 		<RadioGroup.Indicator>x</RadioGroup.Indicator>
 	</RadioGroup.Item>
@@ -67,7 +70,8 @@ The group also sends `disabled`, `readonly` and `required` down to each button.
 ## Accessibility
 
 - `RadioGroup.Root` has `role="radiogroup"`, with `aria-orientation`, `aria-required`, `aria-disabled` and `aria-readonly`. That role supports all four. The `group` role of a checkbox group supports none of them.
-- Give the group an accessible name with `aria-label` or `aria-labelledby`.
+- Give the group an accessible name with `RadioGroup.Label`, or with `aria-label` on the root. The label writes `aria-labelledby` on the group. An `aria-labelledby` that you give stands, thus your own element wins.
+- `RadioGroup.Label` renders a `<span>`, and not a `<label>`. A `<label>` names one control, thus it cannot name a set.
 - Each `RadioGroup.Item` has `role="radio"` with `aria-checked`, and it takes its tab stop from the group.
 - `Enter` does not select. It submits the form, which is the behavior of a native radio button.
 

--- a/packages/ui/src/lib/checkbox-group/README.md
+++ b/packages/ui/src/lib/checkbox-group/README.md
@@ -9,11 +9,13 @@ required state, and it reports the counts a parent "select all" checkbox needs.
 ## Anatomy
 
 - `CheckboxGroup.Root`
+- `CheckboxGroup.Label`
 - `CheckboxGroup.Item`
 - `CheckboxGroup.Indicator`
 
 ```svelte
-<CheckboxGroup.Root name="colors" defaultValue={['red']} aria-label="Colors">
+<CheckboxGroup.Root name="colors" defaultValue={['red']}>
+	<CheckboxGroup.Label>Colors</CheckboxGroup.Label>
 	<Checkbox.Root value="red">
 		<Checkbox.Indicator>x</Checkbox.Indicator>
 		Red
@@ -66,7 +68,14 @@ required state, and it reports the counts a parent "select all" checkbox needs.
   `role="group"` does not support that property. It also never goes down to the boxes. Native
   `required` on a checkbox demands that one box. It would thus turn "at least one" into
   "every one". Put the word in the group label, and give the reason with `aria-describedby`.
-- Provide an accessible group name with `aria-label` or `aria-labelledby`.
+- Provide an accessible group name with `CheckboxGroup.Label`, or with `aria-label` on the root for
+  a name the user does not see. Two labels read as one name, in the order they appear. An
+  `aria-labelledby` that the caller gives stands, thus an element of your own wins.
+- `CheckboxGroup.Label` renders a span, and not a `<label>`: a `<label>` names one control, thus it
+  cannot name a set.
+- The id reaches the group through the context. The server cannot do that: the group tag is
+  already written when the label registers. Thus `aria-labelledby` appears at hydration. Give
+  `aria-label` as well when the name must be there on the first paint.
 - Every checkbox keeps its own tab stop, and `Space` toggles the focused one. The group adds no
   arrow-key navigation. This matches the APG, React Aria and Base UI: React Aria gives each
   checkbox of a group `tabindex="0"`, measured on its own live example. Arrow keys and one tab

--- a/packages/ui/src/lib/checkbox-group/TODO.md
+++ b/packages/ui/src/lib/checkbox-group/TODO.md
@@ -18,7 +18,7 @@ Track CheckboxGroup work with a single mandatory TODO format.
 - [x] [S][P0][Area: Accessibility][Owner: Unassigned][Target: Done] Honor the focus state contract, and check it with `test-utils/focus-contract`.
 - [x] [S][P1][Area: API][Owner: Unassigned][Target: Done] Report `allSelected` and `someSelected`, and expose `selectAll` and `clearAll` for a parent checkbox.
 - [x] [M][P0][Area: Testing][Owner: Unassigned][Target: Done] Add coverage for uncontrolled and controlled value, group state, removal, teardown, tab order, form submission and the parent checkbox.
-- [ ] [S][P1][Area: API][Owner: Unassigned][Target: TBD] Add a `CheckboxGroup.Label` part, so the group names itself without `aria-labelledby` by hand.
+- [x] [S][P1][Area: API][Owner: Unassigned][Target: Done] Add a `CheckboxGroup.Label` part, so the group names itself without `aria-labelledby` by hand.
 - [ ] [M][P1][Area: API][Owner: Unassigned][Target: TBD] Give the parent checkbox a first-class API, the way Base UI does with `allValues` and a `parent` prop, instead of `bind:context` by hand.
 - [ ] [C][P2][Area: Forms][Owner: Unassigned][Target: TBD] Enforce a minimum count for `required`, and report it through constraint validation with `aria-describedby`, the way React Aria does.
 - [ ] [C][P2][Area: State][Owner: Unassigned][Target: TBD] Restore the group value on form reset from the root, instead of one checkbox at a time.

--- a/packages/ui/src/lib/checkbox-group/index.parts.ts
+++ b/packages/ui/src/lib/checkbox-group/index.parts.ts
@@ -1,4 +1,5 @@
 export { default as Root } from './root/checkbox-group-root.svelte';
+export { default as Label } from './label/checkbox-group-label.svelte';
 // `Item` and `Indicator` are `Checkbox.Root` and `Checkbox.Indicator` under the namespace of the
 // group. A checkbox works on its own, so it keeps its own name; this pair only gives every group
 // in the library the same shape — `Group.Root` with `Group.Item` inside.

--- a/packages/ui/src/lib/checkbox-group/index.ts
+++ b/packages/ui/src/lib/checkbox-group/index.ts
@@ -1,12 +1,15 @@
 import type { ComponentProps } from 'svelte';
 import type CheckboxIndicatorComponent from '../checkbox/indicator/checkbox-indicator.svelte';
 import type CheckboxRootComponent from '../checkbox/root/checkbox-root.svelte';
+import type CheckboxGroupLabelComponent from './label/checkbox-group-label.svelte';
 import type CheckboxGroupRootComponent from './root/checkbox-group-root.svelte';
 
 export * as CheckboxGroup from './index.parts.js';
 
 export { default as CheckboxGroupRoot } from './root/checkbox-group-root.svelte';
+export { default as CheckboxGroupLabel } from './label/checkbox-group-label.svelte';
 export type CheckboxGroupRootProps = ComponentProps<typeof CheckboxGroupRootComponent>;
+export type CheckboxGroupLabelProps = ComponentProps<typeof CheckboxGroupLabelComponent>;
 export type CheckboxGroupItemProps = ComponentProps<typeof CheckboxRootComponent>;
 export type CheckboxGroupIndicatorProps = ComponentProps<typeof CheckboxIndicatorComponent>;
 export {

--- a/packages/ui/src/lib/checkbox-group/label/checkbox-group-label-orphan-test.svelte
+++ b/packages/ui/src/lib/checkbox-group/label/checkbox-group-label-orphan-test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { CheckboxGroup } from '../index';
+</script>
+
+<CheckboxGroup.Label>Colors</CheckboxGroup.Label>

--- a/packages/ui/src/lib/checkbox-group/label/checkbox-group-label-test.svelte
+++ b/packages/ui/src/lib/checkbox-group/label/checkbox-group-label-test.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { CheckboxGroup } from '../index';
+
+	type Props = {
+		showLabel?: boolean;
+		showSecondLabel?: boolean;
+		ariaLabelledBy?: string;
+	};
+
+	let { showLabel = true, showSecondLabel = false, ariaLabelledBy }: Props = $props();
+
+	let showLabelOverride = $state<boolean | null>(null);
+
+	const renderedShowLabel = $derived(showLabelOverride ?? showLabel);
+</script>
+
+<span id="outside-label" data-testid="outside-label">Outside</span>
+
+<CheckboxGroup.Root aria-labelledby={ariaLabelledBy} data-testid="checkbox-group">
+	{#if renderedShowLabel}
+		<CheckboxGroup.Label data-testid="checkbox-group-label">Colors</CheckboxGroup.Label>
+	{/if}
+
+	{#if showSecondLabel}
+		<CheckboxGroup.Label data-testid="checkbox-group-label-2">required</CheckboxGroup.Label>
+	{/if}
+
+	<CheckboxGroup.Item value="red" aria-label="Red" data-testid="checkbox-red">
+		<CheckboxGroup.Indicator>x</CheckboxGroup.Indicator>
+		<span>Red</span>
+	</CheckboxGroup.Item>
+</CheckboxGroup.Root>
+
+<button type="button" data-remove-label onclick={() => (showLabelOverride = false)}>
+	Remove label
+</button>

--- a/packages/ui/src/lib/checkbox-group/label/checkbox-group-label.svelte
+++ b/packages/ui/src/lib/checkbox-group/label/checkbox-group-label.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import type { CheckboxGroupLabelProps } from '../types.js';
+	import { getCheckboxGroupContext } from '../root/context.svelte';
+
+	/**
+	 * CheckboxGroup.Label — the accessible name of the group.
+	 *
+	 * It registers its id with the root, which gives it to the group element as
+	 * `aria-labelledby`. A bare heading beside the group leaves the group unnamed: a
+	 * `role="group"` takes its name from `aria-labelledby` or `aria-label`, never from the text
+	 * near it. It renders a `<span>` and not a `<label>`, because a `<label>` names one control.
+	 */
+	let {
+		children,
+		class: className = '',
+		id: idProp,
+		...restProps
+	}: CheckboxGroupLabelProps = $props();
+
+	const checkboxGroup = getCheckboxGroupContext();
+
+	if (!checkboxGroup) {
+		throw new Error('CheckboxGroup.Label must be used within CheckboxGroup.Root.');
+	}
+
+	const group = checkboxGroup;
+	const generatedId = $props.id();
+	const id = $derived(idProp ?? generatedId);
+
+	// The returned unregister runs on destroy, and again whenever the id changes.
+	$effect(() => group.registerLabel(id));
+</script>
+
+<span {...restProps} {id} class={className} data-checkbox-group-label="true">
+	{@render children?.()}
+</span>

--- a/packages/ui/src/lib/checkbox-group/label/checkbox-group-label.test.ts
+++ b/packages/ui/src/lib/checkbox-group/label/checkbox-group-label.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import CheckboxGroupLabelOrphanTest from './checkbox-group-label-orphan-test.svelte';
+import CheckboxGroupLabelTest from './checkbox-group-label-test.svelte';
+
+function getGroup() {
+	return document.querySelector<HTMLElement>('[data-testid="checkbox-group"]')!;
+}
+
+function getLabel(testId = 'checkbox-group-label') {
+	return document.querySelector<HTMLElement>(`[data-testid="${testId}"]`)!;
+}
+
+describe('CheckboxGroup.Label', () => {
+	it('names the group', async () => {
+		const screen = render(CheckboxGroupLabelTest);
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBe(getLabel().id);
+		await expect.element(screen.getByRole('group', { name: 'Colors' })).toBeInTheDocument();
+	});
+
+	// Two labels read as one name, in the order they appear, the same as `Dialog.Title`.
+	it('joins the ids of every label', async () => {
+		render(CheckboxGroupLabelTest, { showSecondLabel: true });
+
+		await expect
+			.poll(() => getGroup().getAttribute('aria-labelledby'))
+			.toBe(`${getLabel().id} ${getLabel('checkbox-group-label-2').id}`);
+	});
+
+	// An `aria-labelledby` on the root is the answer of the caller, thus it stands.
+	it('keeps an aria-labelledby that the caller gives', async () => {
+		render(CheckboxGroupLabelTest, { ariaLabelledBy: 'outside-label' });
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBe('outside-label');
+	});
+
+	it('drops the name when the label leaves the tree', async () => {
+		render(CheckboxGroupLabelTest);
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBe(getLabel().id);
+
+		await userEvent.click(document.querySelector<HTMLButtonElement>('[data-remove-label]')!);
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBeNull();
+	});
+
+	it('rejects a label with no group', () => {
+		expect(() => render(CheckboxGroupLabelOrphanTest)).toThrowError(
+			/must be used within CheckboxGroup.Root/
+		);
+	});
+});

--- a/packages/ui/src/lib/checkbox-group/root/checkbox-group-root.svelte
+++ b/packages/ui/src/lib/checkbox-group/root/checkbox-group-root.svelte
@@ -19,6 +19,7 @@
 		class: className = '',
 		element = $bindable<HTMLDivElement | null>(null),
 		context = $bindable(),
+		'aria-labelledby': ariaLabelledBy,
 		...restProps
 	}: CheckboxGroupRootProps = $props();
 
@@ -105,6 +106,7 @@
 	bind:this={rootRef}
 	id={instanceId}
 	role="group"
+	aria-labelledby={ariaLabelledBy ?? checkboxGroup.labelledBy}
 	class={className}
 	data-checkbox-group-root="true"
 	data-orientation={currentOrientation}

--- a/packages/ui/src/lib/checkbox-group/root/context.svelte.ts
+++ b/packages/ui/src/lib/checkbox-group/root/context.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, setContext } from 'svelte';
+import { getContext, setContext, untrack } from 'svelte';
 import { SvelteMap, SvelteSet } from 'svelte/reactivity';
 import { asCommand } from '../../internal/as-command.js';
 
@@ -32,11 +32,15 @@ export type CheckboxGroupContext = {
 	isReadOnly: boolean;
 	isRequired: boolean;
 	orientation: CheckboxGroupOrientation;
+	/** The ids of the `CheckboxGroup.Label` parts, for `aria-labelledby` on the group. */
+	labelledBy: string | undefined;
 	selectedValues: Set<CheckboxGroupValue>;
 	/** Every registered checkbox is selected, and there is at least one. */
 	allSelected: boolean;
 	/** Some but not all registered checkboxes are selected. Drives a parent `indeterminate`. */
 	someSelected: boolean;
+	/** Registers a label id; the returned function unregisters it. */
+	registerLabel: (id: string) => () => void;
 	registerCheckbox: (
 		value: CheckboxGroupValue,
 		options: { isDisabled?: boolean; element?: HTMLElement | null; owner?: symbol }
@@ -78,6 +82,7 @@ export function createCheckboxGroupContext(
 	let isReadOnly = $state(options.isReadOnly ?? false);
 	let isRequired = $state(options.isRequired ?? false);
 	let orientation = $state(options.orientation ?? 'vertical');
+	let labelIds = $state<string[]>([]);
 	// A `SvelteSet` carries its own reactivity, so it is mutated in place rather than
 	// reassigned: a plain Set behind `$state` would need a new instance for every change,
 	// and it would invalidate every reader of the group on each one.
@@ -299,6 +304,9 @@ export function createCheckboxGroupContext(
 		get orientation() {
 			return orientation;
 		},
+		get labelledBy() {
+			return labelIds.length > 0 ? labelIds.join(' ') : undefined;
+		},
 		get selectedValues() {
 			return selectedValues;
 		},
@@ -308,6 +316,17 @@ export function createCheckboxGroupContext(
 		get someSelected() {
 			const selectedCount = checkboxOrder.filter((value) => selectedValues.has(value)).length;
 			return selectedCount > 0 && selectedCount < checkboxOrder.length;
+		},
+		// `untrack` because the caller registers from an effect: reading `labelIds` here would
+		// make that effect depend on what it writes, and the pair would run without end.
+		registerLabel(id: string) {
+			untrack(() => {
+				labelIds = [...labelIds, id];
+			});
+			return () =>
+				untrack(() => {
+					labelIds = labelIds.filter((candidate) => candidate !== id);
+				});
 		},
 		registerCheckbox: asCommand(registerCheckbox),
 		unregisterCheckbox: asCommand(unregisterCheckbox),

--- a/packages/ui/src/lib/checkbox-group/types.ts
+++ b/packages/ui/src/lib/checkbox-group/types.ts
@@ -58,3 +58,14 @@ export type CheckboxGroupRootProps = Omit<HTMLAttributes<HTMLDivElement>, 'child
 	 */
 	context?: CheckboxGroupContext;
 };
+
+export type CheckboxGroupLabelProps = Omit<
+	HTMLAttributes<HTMLSpanElement>,
+	'children' | 'class' | 'id'
+> & {
+	/** The name of the group. */
+	children?: Snippet;
+	class?: string;
+	/** The id of the label element. The component makes one when you give none. */
+	id?: string;
+};

--- a/packages/ui/src/lib/radio-group/README.md
+++ b/packages/ui/src/lib/radio-group/README.md
@@ -9,11 +9,13 @@ state, and it controls the roving focus the pattern asks for.
 ## Anatomy
 
 - `RadioGroup.Root`
+- `RadioGroup.Label`
 - `RadioGroup.Item`
 - `RadioGroup.Indicator`
 
 ```svelte
-<RadioGroup.Root name="size" defaultValue="medium" aria-label="Size">
+<RadioGroup.Root name="size" defaultValue="medium">
+	<RadioGroup.Label>Size</RadioGroup.Label>
 	<RadioGroup.Item value="small">
 		<RadioGroup.Indicator>x</RadioGroup.Indicator>
 		Small
@@ -59,12 +61,22 @@ input for the form.
 
 `RadioGroup.Indicator` supports `forceMount`. It is in the DOM only while its radio is checked.
 
+`RadioGroup.Label` supports `children`, `class`, `id` and the usual `HTMLAttributes<HTMLSpanElement>`.
+It renders a span, and it registers its id with the group as `aria-labelledby`.
+
 ## Accessibility
 
 - `RadioGroup.Root` renders `role="radiogroup"`, with `aria-orientation`, `aria-required`,
   `aria-disabled` and `aria-readonly`. That role supports all four, which the plain `group` role of
   a checkbox group does not.
-- Give the group an accessible name with `aria-label` or `aria-labelledby`.
+- Give the group an accessible name with `RadioGroup.Label`, or with `aria-label` on the root for a
+  name the user does not see. Two labels read as one name, in the order they appear. An
+  `aria-labelledby` that the caller gives stands, thus an element of your own wins.
+- `RadioGroup.Label` renders a span, and not a `<label>`: a `<label>` names one control, thus it
+  cannot name a set.
+- The id reaches the group through the context. The server cannot do that: the group tag is
+  already written when the label registers. Thus `aria-labelledby` appears at hydration. Give
+  `aria-label` as well when the name must be there on the first paint.
 - The group holds **one** tab stop, on the checked radio, and on the first enabled radio while
   nothing is checked. Thus Tab enters the group where the user left it, and Tab leaves the group
   rather than walking through it.

--- a/packages/ui/src/lib/radio-group/TODO.md
+++ b/packages/ui/src/lib/radio-group/TODO.md
@@ -16,7 +16,7 @@ Track RadioGroup work with a single mandatory TODO format.
 - [x] [M][P0][Area: State][Owner: Unassigned][Target: Done] Keep the value when the selected radio leaves the tree, and move the tab stop instead.
 - [x] [S][P0][Area: Forms][Owner: Unassigned][Target: Done] Share `name` and `form` with every radio, and spread group `disabled`, `readonly` and `required`.
 - [x] [M][P0][Area: Testing][Owner: Unassigned][Target: Done] Add coverage for the roving tab stop, arrow selection, wrapping, disabled radios, form submission and the focus contract.
-- [ ] [S][P1][Area: API][Owner: Unassigned][Target: TBD] Add a `RadioGroup.Label` part, so the group names itself without `aria-labelledby` by hand.
+- [x] [S][P1][Area: API][Owner: Unassigned][Target: Done] Add a `RadioGroup.Label` part, so the group names itself without `aria-labelledby` by hand.
 - [ ] [S][P1][Area: API][Owner: Unassigned][Target: TBD] Add an optional `nativeButton` rendering mode to `RadioGroup.Item`, for sibling-label patterns.
 - [ ] [C][P2][Area: Animation][Owner: Unassigned][Target: TBD] Add indicator presence data for enter and exit animations.
 - [x] [S][P1][Area: Accessibility][Owner: Unassigned][Target: Done] Adopt `watchFocusVisible`, so a key press after a pointer press brings the ring back.

--- a/packages/ui/src/lib/radio-group/index.parts.ts
+++ b/packages/ui/src/lib/radio-group/index.parts.ts
@@ -1,3 +1,4 @@
 export { default as Root } from './root/radio-group-root.svelte';
+export { default as Label } from './label/radio-group-label.svelte';
 export { default as Item } from './item/radio-group-item.svelte';
 export { default as Indicator } from './indicator/radio-group-indicator.svelte';

--- a/packages/ui/src/lib/radio-group/index.ts
+++ b/packages/ui/src/lib/radio-group/index.ts
@@ -1,14 +1,17 @@
 import type { ComponentProps } from 'svelte';
 import type RadioGroupIndicatorComponent from './indicator/radio-group-indicator.svelte';
+import type RadioGroupLabelComponent from './label/radio-group-label.svelte';
 import type RadioGroupItemComponent from './item/radio-group-item.svelte';
 import type RadioGroupRootComponent from './root/radio-group-root.svelte';
 
 export * as RadioGroup from './index.parts.js';
 
 export { default as RadioGroupRoot } from './root/radio-group-root.svelte';
+export { default as RadioGroupLabel } from './label/radio-group-label.svelte';
 export { default as RadioGroupItem } from './item/radio-group-item.svelte';
 export { default as RadioGroupIndicator } from './indicator/radio-group-indicator.svelte';
 export type RadioGroupRootProps = ComponentProps<typeof RadioGroupRootComponent>;
+export type RadioGroupLabelProps = ComponentProps<typeof RadioGroupLabelComponent>;
 export type RadioGroupItemProps = ComponentProps<typeof RadioGroupItemComponent>;
 export type RadioGroupIndicatorProps = ComponentProps<typeof RadioGroupIndicatorComponent>;
 

--- a/packages/ui/src/lib/radio-group/label/radio-group-label-orphan-test.svelte
+++ b/packages/ui/src/lib/radio-group/label/radio-group-label-orphan-test.svelte
@@ -1,0 +1,5 @@
+<script lang="ts">
+	import { RadioGroup } from '../index';
+</script>
+
+<RadioGroup.Label>Colors</RadioGroup.Label>

--- a/packages/ui/src/lib/radio-group/label/radio-group-label-test.svelte
+++ b/packages/ui/src/lib/radio-group/label/radio-group-label-test.svelte
@@ -1,0 +1,36 @@
+<script lang="ts">
+	import { RadioGroup } from '../index';
+
+	type Props = {
+		showLabel?: boolean;
+		showSecondLabel?: boolean;
+		ariaLabelledBy?: string;
+	};
+
+	let { showLabel = true, showSecondLabel = false, ariaLabelledBy }: Props = $props();
+
+	let showLabelOverride = $state<boolean | null>(null);
+
+	const renderedShowLabel = $derived(showLabelOverride ?? showLabel);
+</script>
+
+<span id="outside-label" data-testid="outside-label">Outside</span>
+
+<RadioGroup.Root aria-labelledby={ariaLabelledBy} data-testid="radio-group">
+	{#if renderedShowLabel}
+		<RadioGroup.Label data-testid="radio-group-label">Colors</RadioGroup.Label>
+	{/if}
+
+	{#if showSecondLabel}
+		<RadioGroup.Label data-testid="radio-group-label-2">required</RadioGroup.Label>
+	{/if}
+
+	<RadioGroup.Item value="red" aria-label="Red" data-testid="radio-red">
+		<RadioGroup.Indicator>x</RadioGroup.Indicator>
+		<span>Red</span>
+	</RadioGroup.Item>
+</RadioGroup.Root>
+
+<button type="button" data-remove-label onclick={() => (showLabelOverride = false)}>
+	Remove label
+</button>

--- a/packages/ui/src/lib/radio-group/label/radio-group-label.svelte
+++ b/packages/ui/src/lib/radio-group/label/radio-group-label.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+	import type { RadioGroupLabelProps } from '../types.js';
+	import { getRadioGroupContext } from '../root/context.svelte';
+
+	/**
+	 * RadioGroup.Label — the accessible name of the group.
+	 *
+	 * It registers its id with the root, which gives it to the group element as
+	 * `aria-labelledby`. A bare heading beside the group leaves the group unnamed: a
+	 * `role="radiogroup"` takes its name from `aria-labelledby` or `aria-label`, never from the
+	 * text near it. It renders a `<span>` and not a `<label>`, because a `<label>` names one
+	 * control.
+	 */
+	let {
+		children,
+		class: className = '',
+		id: idProp,
+		...restProps
+	}: RadioGroupLabelProps = $props();
+
+	const radioGroup = getRadioGroupContext();
+
+	if (!radioGroup) {
+		throw new Error('RadioGroup.Label must be used within RadioGroup.Root.');
+	}
+
+	const group = radioGroup;
+	const generatedId = $props.id();
+	const id = $derived(idProp ?? generatedId);
+
+	// The returned unregister runs on destroy, and again whenever the id changes.
+	$effect(() => group.registerLabel(id));
+</script>
+
+<span {...restProps} {id} class={className} data-radio-group-label="true">
+	{@render children?.()}
+</span>

--- a/packages/ui/src/lib/radio-group/label/radio-group-label.test.ts
+++ b/packages/ui/src/lib/radio-group/label/radio-group-label.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest';
+import { userEvent } from 'vitest/browser';
+import { render } from 'vitest-browser-svelte';
+import RadioGroupLabelOrphanTest from './radio-group-label-orphan-test.svelte';
+import RadioGroupLabelTest from './radio-group-label-test.svelte';
+
+function getGroup() {
+	return document.querySelector<HTMLElement>('[data-testid="radio-group"]')!;
+}
+
+function getLabel(testId = 'radio-group-label') {
+	return document.querySelector<HTMLElement>(`[data-testid="${testId}"]`)!;
+}
+
+describe('RadioGroup.Label', () => {
+	it('names the group', async () => {
+		const screen = render(RadioGroupLabelTest);
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBe(getLabel().id);
+		await expect.element(screen.getByRole('radiogroup', { name: 'Colors' })).toBeInTheDocument();
+	});
+
+	// Two labels read as one name, in the order they appear, the same as `Dialog.Title`.
+	it('joins the ids of every label', async () => {
+		render(RadioGroupLabelTest, { showSecondLabel: true });
+
+		await expect
+			.poll(() => getGroup().getAttribute('aria-labelledby'))
+			.toBe(`${getLabel().id} ${getLabel('radio-group-label-2').id}`);
+	});
+
+	// An `aria-labelledby` on the root is the answer of the caller, thus it stands.
+	it('keeps an aria-labelledby that the caller gives', async () => {
+		render(RadioGroupLabelTest, { ariaLabelledBy: 'outside-label' });
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBe('outside-label');
+	});
+
+	it('drops the name when the label leaves the tree', async () => {
+		render(RadioGroupLabelTest);
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBe(getLabel().id);
+
+		await userEvent.click(document.querySelector<HTMLButtonElement>('[data-remove-label]')!);
+
+		await expect.poll(() => getGroup().getAttribute('aria-labelledby')).toBeNull();
+	});
+
+	it('rejects a label with no group', () => {
+		expect(() => render(RadioGroupLabelOrphanTest)).toThrowError(
+			/must be used within RadioGroup.Root/
+		);
+	});
+});

--- a/packages/ui/src/lib/radio-group/root/context.svelte.ts
+++ b/packages/ui/src/lib/radio-group/root/context.svelte.ts
@@ -1,4 +1,4 @@
-import { getContext, setContext } from 'svelte';
+import { getContext, setContext, untrack } from 'svelte';
 import { SvelteMap } from 'svelte/reactivity';
 import { asCommand } from '../../internal/as-command.js';
 
@@ -32,8 +32,12 @@ export type RadioGroupContext = {
 	isReadOnly: boolean;
 	isRequired: boolean;
 	orientation: RadioGroupOrientation;
+	/** The ids of the `RadioGroup.Label` parts, for `aria-labelledby` on the group. */
+	labelledBy: string | undefined;
 	selectedValue: RadioGroupValue | null;
 	focusedValue: RadioGroupValue | null;
+	/** Registers a label id; the returned function unregisters it. */
+	registerLabel: (id: string) => () => void;
 	registerRadio: (
 		value: RadioGroupValue,
 		options: { isDisabled?: boolean; element?: HTMLElement | null; owner?: symbol }
@@ -76,6 +80,7 @@ export function createRadioGroupContext(
 	let isReadOnly = $state(options.isReadOnly ?? false);
 	let isRequired = $state(options.isRequired ?? false);
 	let orientation = $state(options.orientation ?? 'vertical');
+	let labelIds = $state<string[]>([]);
 	let selectedValue = $state<RadioGroupValue | null>(options.initialValue ?? null);
 	let focusedValue = $state<RadioGroupValue | null>(null);
 	let focusVisible = $state(false);
@@ -326,6 +331,9 @@ export function createRadioGroupContext(
 		get isRequired() {
 			return isRequired;
 		},
+		get labelledBy() {
+			return labelIds.length > 0 ? labelIds.join(' ') : undefined;
+		},
 		get orientation() {
 			return orientation;
 		},
@@ -348,6 +356,17 @@ export function createRadioGroupContext(
 		setFocusedValue: asCommand(setFocusedValue),
 		focusValue: asCommand(focusValue),
 		setFocusVisible: asCommand(setFocusVisible),
+		// `untrack` because the caller registers from an effect: reading `labelIds` here would
+		// make that effect depend on what it writes, and the pair would run without end.
+		registerLabel(id: string) {
+			untrack(() => {
+				labelIds = [...labelIds, id];
+			});
+			return () =>
+				untrack(() => {
+					labelIds = labelIds.filter((candidate) => candidate !== id);
+				});
+		},
 		isSelected,
 		isFocused,
 		isFocusVisible,

--- a/packages/ui/src/lib/radio-group/root/radio-group-root.svelte
+++ b/packages/ui/src/lib/radio-group/root/radio-group-root.svelte
@@ -31,6 +31,7 @@
 		context = $bindable(),
 		onkeydown: onKeyDownExternal,
 		onmousedown: onMouseDownExternal,
+		'aria-labelledby': ariaLabelledBy,
 		...restProps
 	}: RadioGroupRootProps = $props();
 
@@ -174,6 +175,7 @@
 	bind:this={rootRef}
 	id={instanceId}
 	role="radiogroup"
+	aria-labelledby={ariaLabelledBy ?? radioGroup.labelledBy}
 	aria-orientation={currentOrientation}
 	aria-required={required || undefined}
 	aria-disabled={disabled || undefined}

--- a/packages/ui/src/lib/radio-group/types.ts
+++ b/packages/ui/src/lib/radio-group/types.ts
@@ -54,3 +54,14 @@ export type RadioGroupRootProps = Omit<
 	/** The state of the group. Use `bind:context` to read the selection from outside. */
 	context?: RadioGroupContext;
 };
+
+export type RadioGroupLabelProps = Omit<
+	HTMLAttributes<HTMLSpanElement>,
+	'children' | 'class' | 'id'
+> & {
+	/** The name of the group. */
+	children?: Snippet;
+	class?: string;
+	/** The id of the label element. The component makes one when you give none. */
+	id?: string;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,8 +112,8 @@ importers:
         specifier: ^5.2.9
         version: 5.2.9
       '@human-kit/markdown':
-        specifier: ^0.3.1
-        version: 0.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+        specifier: ^0.3.2
+        version: 0.3.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
       '@human-kit/ui':
         specifier: workspace:*
         version: link:../packages/ui
@@ -532,8 +532,8 @@ packages:
   '@fontsource-variable/roboto-serif@5.2.9':
     resolution: {integrity: sha512-C502AILLgiRZmP3mgXXJiYp8/tQ+J/XQWw/dWtlRgE9X0yziBse9VHM9pCgaWqqzkdz4JB36fc0eYz0UritJIQ==}
 
-  '@human-kit/markdown@0.3.1':
-    resolution: {integrity: sha512-+rBrFW01tmhkIteA71yidABWDySc/lIL4ro4L95I0/wcESs4p5GQtB8bNoi1/RUY5XUNm/zIST5AZIVVCKzqTw==}
+  '@human-kit/markdown@0.3.2':
+    resolution: {integrity: sha512-MqYyFAqcvFhoJqVyqla7N++vQhXQ21htpoFWLO9m1aLp865OQztsqrhNPDiOt27rTdIhK/8MLqYyqvU1icaZ6g==}
     hasBin: true
     peerDependencies:
       svelte: ^5.0.0
@@ -3213,7 +3213,7 @@ snapshots:
 
   '@fontsource-variable/roboto-serif@5.2.9': {}
 
-  '@human-kit/markdown@0.3.1(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
+  '@human-kit/markdown@0.3.2(svelte@5.56.4(@typescript-eslint/types@8.62.1))(vite@7.3.6(@types/node@20.19.43)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))':
     dependencies:
       property-information: 7.2.0
       remark-gfm: 4.0.1


### PR DESCRIPTION
## What this adds

`CheckboxGroup.Label` and `RadioGroup.Label`. The part names its group: it registers its id with the root, which gives it to the group element as `aria-labelledby`.

```svelte
<RadioGroup.Root name="size" defaultValue="medium">
	<RadioGroup.Label>Size</RadioGroup.Label>
	<RadioGroup.Item value="small">…</RadioGroup.Item>
</RadioGroup.Root>
```

- Two labels read as one name, in the order they appear, the same as `Dialog.Title`.
- An `aria-labelledby` that the caller gives stands, thus an element of your own wins.
- A label that leaves the tree takes its id with it.
- A label with no group reports an error.
- It renders a `<span>`, and not a `<label>`. A `<label>` names one control, thus it cannot name a set.

The registry writes under `untrack`. The caller registers from an effect, thus a read of the id list inside that write would make the effect depend on what it writes, and the pair would run without end. The first run of the tests showed exactly that: "Maximum update depth exceeded".

## One limit, written in both READMEs

The id reaches the group through the context. The server cannot do that — the group tag is already written when the label registers — thus `aria-labelledby` appears at hydration. Give `aria-label` as well when the name must be there on the first paint. `Dialog.Title` has the same shape.

## Also in here

`@human-kit/markdown` moves to 0.3.2, which runs `hk-extract-api` again when a package manager starts it. With 0.3.1 the guard that keeps the CLI from running on import compared the entry path with the module url as text, and a package manager starts the CLI through a shim, thus the two never matched: the command exited with no work, no output file and no message.

That is why the API reference of `RadioGroup.Item` still listed the props of `RadioGroup.Root`, and why I read "no difference" as proof in #92. This regenerates both files.

## Verification

`pnpm test` — 1816 tests pass, 10 of them new. `pnpm run test:ssr` — 33 pass. `pnpm run check` — 967 files, no errors. `pnpm run lint` passes. `pnpm docs:api` leaves no difference.